### PR TITLE
Add agent validation schema and endpoint

### DIFF
--- a/services/agent-api/package.json
+++ b/services/agent-api/package.json
@@ -16,7 +16,8 @@
   "dependencies": {
     "cors": "^2.8.5",
     "dotenv": "^17.2.0",
-    "express": "^5.1.0"
+    "express": "^5.1.0",
+    "zod": "^4.0.5"
   },
   "devDependencies": {
     "@types/cors": "^2.8.19",

--- a/services/agent-api/src/index.ts
+++ b/services/agent-api/src/index.ts
@@ -1,6 +1,7 @@
 import express from "express";
 import cors from "cors";
 import dotenv from "dotenv";
+import { agentSchema } from "../../validation/agentSchema";
 dotenv.config();
 
 const app = express();
@@ -31,6 +32,14 @@ app.post("/agent", (req, res) => {
   // placeholder agent creation
   const agent = { id: Date.now(), name: req.body.name };
   res.json(agent);
+});
+
+app.post("/validate-agent", (req, res) => {
+  const result = agentSchema.safeParse(req.body);
+  if (!result.success) {
+    return res.status(400).json({ errors: result.error.errors });
+  }
+  res.json({ valid: true });
 });
 
 const port = process.env.PORT || 4000;

--- a/validation/agentSchema.ts
+++ b/validation/agentSchema.ts
@@ -1,0 +1,8 @@
+import { z } from 'zod';
+
+export const agentSchema = z.object({
+  name: z.string().min(1, 'name is required'),
+  description: z.string().optional(),
+});
+
+export type Agent = z.infer<typeof agentSchema>;


### PR DESCRIPTION
## Summary
- add a Zod schema for agents in `validation/agentSchema.ts`
- install `zod` in the agent-api service
- add `/validate-agent` endpoint that validates the request body against the new schema

## Testing
- `npm test` (fails: No tests specified)
- `npm test` in `services/agent-api` (fails: Missing script)

------
https://chatgpt.com/codex/tasks/task_e_6876872b1aa48329844ae6166c44e97e