### PR TITLE
Add agent export script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ dist/
 .expo/
 logs/
 build/
+export/

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "scripts": {
     "lint": "echo \"No lint script defined\"",
     "build": "echo \"No build script defined\"",
-    "test": "echo \"No tests specified\""
+    "test": "echo \"No tests specified\"",
+    "export-agents": "node scripts/export-agents.js"
   }
 }

--- a/scripts/export-agents.js
+++ b/scripts/export-agents.js
@@ -1,0 +1,40 @@
+const fs = require('fs/promises');
+const path = require('path');
+
+const AGENTS_DIR = path.join(__dirname, '..', 'apps', 'backend', 'src', 'agents');
+const EXPORT_DIR = path.join(__dirname, '..', 'export', 'agents');
+const COMPOSE_PATH = path.join(__dirname, '..', 'export', 'docker-compose.yml');
+
+async function copyAgents() {
+  await fs.mkdir(EXPORT_DIR, { recursive: true });
+  const entries = await fs.readdir(AGENTS_DIR, { withFileTypes: true });
+  const agentNames = [];
+  for (const entry of entries) {
+    if (entry.name.startsWith('.')) continue; // skip .gitkeep and hidden files
+    const srcPath = path.join(AGENTS_DIR, entry.name);
+    const destPath = path.join(EXPORT_DIR, entry.name);
+    await fs.cp(srcPath, destPath, { recursive: true });
+    agentNames.push(entry.name);
+  }
+  return agentNames;
+}
+
+function generateCompose(agentNames) {
+  const lines = ["version: '3.8'", 'services:', `  gateway:`, `    build: ../apps/backend`, `    ports:`, `      - '4000:4000'`, `    env_file:`, `      - ../.env.example`];
+  for (const name of agentNames) {
+    lines.push(`  ${name}:`, `    build: ./agents/${name}`);
+  }
+  return lines.join('\n') + '\n';
+}
+
+async function main() {
+  const names = await copyAgents();
+  const compose = generateCompose(names);
+  await fs.writeFile(COMPOSE_PATH, compose);
+  console.log(`Exported ${names.length} agents`);
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- create `scripts/export-agents.js` to export backend agents and generate a compose file
- ignore the `export/` folder and add npm script `export-agents`

## Testing
- `npm run lint`
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68768763911c8329bbb928dd7c00f262