### PR TITLE
Add Apollo Gateway service

### DIFF
--- a/apps/gateway/Dockerfile
+++ b/apps/gateway/Dockerfile
@@ -1,0 +1,5 @@
+FROM node:18-slim
+WORKDIR /app
+COPY . .
+RUN npm install && npm run build
+CMD ["node", "dist/index.js"]

--- a/apps/gateway/index.ts
+++ b/apps/gateway/index.ts
@@ -1,0 +1,31 @@
+import { ApolloGateway } from '@apollo/gateway';
+import { ApolloServer } from 'apollo-server';
+import dotenv from 'dotenv';
+
+dotenv.config();
+
+async function loadSubgraphs() {
+  const serviceUrl = process.env.AGENT_SERVICE_URL || 'http://backend:4000';
+  try {
+    const res = await fetch(`${serviceUrl}/agents/export`);
+    const json = await res.json();
+    return (json.data || []) as Array<{ name: string; url: string }>;
+  } catch (err) {
+    console.error('Failed to load subgraphs', err);
+    return [];
+  }
+}
+
+async function start() {
+  const serviceList = await loadSubgraphs();
+  const gateway = new ApolloGateway({ serviceList });
+  const server = new ApolloServer({ gateway });
+  const port = process.env.PORT ? Number(process.env.PORT) : 4001;
+  server.listen({ port }).then(({ url }) => {
+    console.log(`🚀 Gateway ready at ${url}`);
+  });
+}
+
+start().catch((err) => {
+  console.error('Gateway failed to start', err);
+});

--- a/apps/gateway/package.json
+++ b/apps/gateway/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "gateway",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "ts-node-dev index.ts",
+    "build": "tsc -p tsconfig.json",
+    "start": "node dist/index.js"
+  },
+  "dependencies": {
+    "@apollo/gateway": "latest",
+    "apollo-server": "latest",
+    "graphql": "latest",
+    "dotenv": "latest"
+  },
+  "devDependencies": {
+    "typescript": "latest",
+    "ts-node-dev": "latest",
+    "@types/node": "latest"
+  }
+}

--- a/apps/gateway/tsconfig.json
+++ b/apps/gateway/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../../packages/tsconfig/tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist"
+  },
+  "include": ["index.ts"]
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,3 +24,11 @@ services:
       - '4000:4000'
     env_file:
       - .env.example
+  gateway:
+    build: ./apps/gateway
+    ports:
+      - '4001:4001'
+    env_file:
+      - .env.example
+    depends_on:
+      - backend


### PR DESCRIPTION
## Summary
- add new `gateway` service for Apollo Gateway
- implement gateway logic to load subgraphs from the backend
- provide Dockerfile, tsconfig, and package.json
- expose the gateway in `docker-compose.yml`

## Testing
- `pnpm install --no-frozen-lockfile`
- `pnpm run build --if-present`

------
https://chatgpt.com/codex/tasks/task_e_68768763dad08329974a10bdc11a8001