### PR TITLE
Implement chat-based agent creation

### DIFF
--- a/client/src/pages/Chat.tsx
+++ b/client/src/pages/Chat.tsx
@@ -27,6 +27,15 @@ export default function Chat() {
     setInput('');
   };
 
+  const createAgent = async () => {
+    await fetch(`${import.meta.env.VITE_API_URL}/create-agent`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ messages }),
+    });
+    alert('Agent created');
+  };
+
   return (
     <div>
       <h2>Chat</h2>
@@ -37,6 +46,7 @@ export default function Chat() {
       </div>
       <input value={input} onChange={(e) => setInput(e.target.value)} />
       <button onClick={sendMessage}>Send</button>
+      <button onClick={createAgent}>Create Agent</button>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- enable user registration and login via the API
- store chat messages and create agents from chat history
- expose `/chat`, `/register`, `/login`, and `/create-agent` endpoints
- allow the client chat page to trigger agent creation

## Testing
- `pnpm run lint --if-present`
- `pnpm run test --if-present`
- `pnpm run build --if-present`


------
https://chatgpt.com/codex/tasks/task_e_6876965fc9d483298f145ece567a5207