### PR TITLE
Fix env vars for supabase client

### DIFF
--- a/services/agent-api/src/supabaseClient.ts
+++ b/services/agent-api/src/supabaseClient.ts
@@ -1,7 +1,7 @@
 import { createClient, SupabaseClient } from '@supabase/supabase-js';
 
-const supabaseUrl = process.env.SUPABASE_URL as string;
-const supabaseAnonKey = process.env.SUPABASE_ANON_KEY as string;
+const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL as string;
+const supabaseAnonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY as string;
 
 export function getSupabaseClient(accessToken?: string): SupabaseClient {
   return createClient(supabaseUrl, supabaseAnonKey, {


### PR DESCRIPTION
## Summary
- align agent-api supabase client env var names with `.env.example`

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_6876bfebe3408329b98521e9a794643e