### PR TITLE
Add OpenAI configuration helper

### DIFF
--- a/services/agent-api/src/openai.ts
+++ b/services/agent-api/src/openai.ts
@@ -1,5 +1,9 @@
-import OpenAI from 'openai';
+import { Configuration, OpenAIApi } from 'openai';
 
-const openai = new OpenAI({ apiKey: process.env.OPENAI_API_KEY });
+const configuration = new Configuration({
+  apiKey: process.env.OPENAI_API_KEY,
+});
+
+const openai = new OpenAIApi(configuration);
 
 export default openai;


### PR DESCRIPTION
## Summary
- configure OpenAI using `Configuration` and `OpenAIApi`

## Testing
- `npm run lint` *(fails: ESLint config missing)*
- `npm test` *(fails: no test script)*
- `npm run lint` at repo root
- `npm test` at repo root

------
https://chatgpt.com/codex/tasks/task_e_6876c855ec608329ab210609d224aee3