### PR TITLE
Add SkipTraceEnricher agent

### DIFF
--- a/apps/backend/src/agents/SkipTraceEnricher/config.ts
+++ b/apps/backend/src/agents/SkipTraceEnricher/config.ts
@@ -1,0 +1,1 @@
+export const defaultStatus = 'pending';

--- a/apps/backend/src/agents/SkipTraceEnricher/resolvers.ts
+++ b/apps/backend/src/agents/SkipTraceEnricher/resolvers.ts
@@ -1,0 +1,24 @@
+import { EnrichedRecord } from './types';
+import { defaultStatus } from './config';
+
+const records: EnrichedRecord[] = [];
+
+const resolvers = {
+  Query: {
+    enrichedRecord: (_: unknown, { id }: { id: string }) =>
+      records.find((r) => r.id === id) || null,
+  },
+  Mutation: {
+    enrich: (_: unknown, { data }: { data: string }) => {
+      const record: EnrichedRecord = {
+        id: String(Date.now()),
+        data,
+        status: defaultStatus,
+      };
+      records.push(record);
+      return record;
+    },
+  },
+};
+
+export default resolvers;

--- a/apps/backend/src/agents/SkipTraceEnricher/schema.graphql
+++ b/apps/backend/src/agents/SkipTraceEnricher/schema.graphql
@@ -1,0 +1,15 @@
+# GraphQL schema for SkipTraceEnricher
+
+type EnrichedRecord {
+  id: ID!
+  data: String!
+  status: String!
+}
+
+type Query {
+  enrichedRecord(id: ID!): EnrichedRecord
+}
+
+type Mutation {
+  enrich(data: String!): EnrichedRecord!
+}

--- a/apps/backend/src/agents/SkipTraceEnricher/tool.ts
+++ b/apps/backend/src/agents/SkipTraceEnricher/tool.ts
@@ -1,0 +1,6 @@
+import { readFileSync } from 'fs';
+import { join } from 'path';
+
+export function loadSchema(): string {
+  return readFileSync(join(__dirname, 'schema.graphql'), 'utf8');
+}

--- a/apps/backend/src/agents/SkipTraceEnricher/types.ts
+++ b/apps/backend/src/agents/SkipTraceEnricher/types.ts
@@ -1,0 +1,5 @@
+export interface EnrichedRecord {
+  id: string;
+  data: string;
+  status: string;
+}

--- a/apps/backend/src/resolvers/index.ts
+++ b/apps/backend/src/resolvers/index.ts
@@ -1,12 +1,15 @@
 import agentResolvers from '../agents/resolvers';
+import skipTraceResolvers from '../agents/SkipTraceEnricher/resolvers';
 
 const resolvers = {
   Query: {
     ping: () => 'pong',
     ...(agentResolvers.Query || {}),
+    ...(skipTraceResolvers.Query || {}),
   },
   Mutation: {
     ...(agentResolvers.Mutation || {}),
+    ...(skipTraceResolvers.Mutation || {}),
   },
 };
 

--- a/apps/backend/src/schema/index.ts
+++ b/apps/backend/src/schema/index.ts
@@ -12,6 +12,11 @@ const agentSchema = readFileSync(
   'utf8'
 );
 
-const typeDefs = [baseSchema, agentSchema].join('\n');
+const skipTraceSchema = readFileSync(
+  join(__dirname, '../agents/SkipTraceEnricher/schema.graphql'),
+  'utf8'
+);
+
+const typeDefs = [baseSchema, agentSchema, skipTraceSchema].join('\n');
 
 export default typeDefs;


### PR DESCRIPTION
## Summary
- implement SkipTraceEnricher agent files
- hook SkipTraceEnricher schema and resolvers into backend

## Testing
- `npm run build` *(fails: Cannot find module 'fs' or its corresponding type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_6877999431a88329a1c590c39d863dc8