### PR TITLE
Implement OpenAI helper and prompt endpoint

### DIFF
--- a/services/agent-api/src/index.ts
+++ b/services/agent-api/src/index.ts
@@ -108,18 +108,22 @@ app.post("/validate-agent", (req, res) => {
 });
 
 app.post("/generate-ai-agent", async (req, res) => {
-  const { template, deepResearch } = req.body;
+  const { prompt } = req.body;
+
+  if (!prompt) {
+    return res.status(400).json({ error: "Missing prompt" });
+  }
 
   try {
     const completion = await openai.chat.completions.create({
       model: "gpt-4o",
       messages: [
         { role: "system", content: systemPrompt },
-        { role: "user", content: JSON.stringify({ template, deepResearch }) },
+        { role: "user", content: prompt },
       ],
     });
-    const content = completion.choices[0].message?.content || "{}";
-    res.json(JSON.parse(content));
+    const content = completion.choices[0].message?.content || "";
+    res.json({ content });
   } catch (err) {
     console.error(err);
     res.status(500).json({ error: "Failed to generate agent" });

--- a/services/agent-api/src/openai.ts
+++ b/services/agent-api/src/openai.ts
@@ -1,7 +1,13 @@
 import { Configuration, OpenAIApi } from 'openai';
 
+const apiKey = process.env.OPENAI_API_KEY;
+
+if (!apiKey) {
+  throw new Error('OPENAI_API_KEY is not set');
+}
+
 const configuration = new Configuration({
-  apiKey: process.env.OPENAI_API_KEY,
+  apiKey,
 });
 
 const openai = new OpenAIApi(configuration);


### PR DESCRIPTION
## Summary
- add helper to create the OpenAI client with error checking
- update `/generate-ai-agent` to send the prompt to OpenAI and respond with the generated content

## Testing
- `pnpm install --ignore-scripts` *(fails: openai@^x.y.z isn't supported)*
- `pnpm run lint`
- `pnpm run test`
- `pnpm run build`


------
https://chatgpt.com/codex/tasks/task_e_687799bc8f9c8329a96825cb925832f3