### PR TITLE
Update export script for compose generation

### DIFF
--- a/scripts/export-agents.js
+++ b/scripts/export-agents.js
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 
 const fs = require('fs/promises');
+const { existsSync } = require('fs');
 const path = require('path');
 
 async function main() {
@@ -10,6 +11,9 @@ async function main() {
   const exportDir = path.join(repoRoot, 'export');
   const exportAgentsDir = path.join(exportDir, 'agents');
   const composeFile = path.join(exportDir, 'docker-compose.yml');
+  if (existsSync(composeFile)) {
+    await fs.rm(composeFile);
+  }
 
   try {
     await fs.access(agentsDir);
@@ -37,7 +41,7 @@ async function main() {
 
 
   const lines = [];
-  lines.push('version: "3"');
+  lines.push('version: "3.8"');
   lines.push('services:');
   lines.push('  gateway:');
   // Build context for the gateway should resolve from the export directory
@@ -45,11 +49,11 @@ async function main() {
   lines.push('    build: ../apps/backend');
   lines.push("    ports:");
   lines.push("      - '4000:4000'");
-  agentNames.forEach(name => {
-    lines.push(`  ${name}:`);
+  agentNames.forEach(agentName => {
+    lines.push(`  ${agentName}:`);
     // Each agent is copied under export/agents so use a relative build path
     // that works when the compose file is run from export/.
-    lines.push(`    build: ./agents/${name}`);
+    lines.push(`    build: ./agents/${agentName}`);
   });
   await fs.mkdir(path.dirname(composeFile), { recursive: true });
   await fs.writeFile(


### PR DESCRIPTION
## Summary
- ensure docker-compose path and clean old file
- generate compose file with version 3.8
- iterate using `agentNames` variable
- import `fs` for `existsSync`

## Testing
- `npm test`
- `node scripts/export-agents.js`

------
https://chatgpt.com/codex/tasks/task_e_687799c470bc8329bcf5d2ca5a565b08