### PR TITLE
Fix supabase env vars in agent-api

### DIFF
--- a/services/agent-api/src/index.ts
+++ b/services/agent-api/src/index.ts
@@ -19,8 +19,8 @@ const stripe = new Stripe(process.env.STRIPE_SECRET_KEY as string, {
 });
 
 const supabase = createClient(
-  process.env.VITE_SUPABASE_URL as string,
-  process.env.VITE_SUPABASE_ANON_KEY as string
+  process.env.NEXT_PUBLIC_SUPABASE_URL as string,
+  process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY as string
 );
 
 const app = express();


### PR DESCRIPTION
## Summary
- align agent-api with NEXT_PUBLIC Supabase env vars

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687799c526c48329b50fa2d1b1c0a105