### PR TITLE
Refactor export-agents script

### DIFF
--- a/scripts/export-agents.js
+++ b/scripts/export-agents.js
@@ -1,7 +1,6 @@
 #!/usr/bin/env node
 
 const fs = require('fs/promises');
-const { existsSync } = require('fs');
 const path = require('path');
 
 async function main() {
@@ -11,9 +10,7 @@ async function main() {
   const exportDir = path.join(repoRoot, 'export');
   const exportAgentsDir = path.join(exportDir, 'agents');
   const composeFile = path.join(exportDir, 'docker-compose.yml');
-  if (existsSync(composeFile)) {
-    await fs.rm(composeFile);
-  }
+  await fs.rm(composeFile, { force: true });
 
   try {
     await fs.access(agentsDir);


### PR DESCRIPTION
## Summary
- clean up `scripts/export-agents.js`
- drop `existsSync` in favour of `fs.rm` with `force: true`
- keep docker compose write path consistent

## Testing
- `npm test`
- `node scripts/export-agents.js`

------
https://chatgpt.com/codex/tasks/task_e_6877a049bfdc8329a9032638c83ce27a