### PR TITLE
Fix agent-api package.json

### DIFF
--- a/services/agent-api/package.json
+++ b/services/agent-api/package.json
@@ -19,8 +19,7 @@
     "dotenv": "^17.2.0",
     "express": "^5.1.0",
     "stripe": "^14.0.0",
-    "openai": "^x.y.z"
-
+    "openai": "^4.48.0"
   },
   "devDependencies": {
     "@types/cors": "^2.8.19",


### PR DESCRIPTION
## Summary
- remove stray GitHub URL fragment
- keep newer `@supabase/supabase-js`
- set valid OpenAI dependency version
- verify package by installing

## Testing
- `pnpm install`

------
https://chatgpt.com/codex/tasks/task_e_6877a04d65488329acea500f282a7282