### PR TITLE
Update API env vars

### DIFF
--- a/services/agent-api/src/index.ts
+++ b/services/agent-api/src/index.ts
@@ -19,8 +19,8 @@ const stripe = new Stripe(process.env.STRIPE_SECRET_KEY as string, {
 
 
 const supabase = createClient(
-  process.env.NEXT_PUBLIC_SUPABASE_URL as string,
-  process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY as string
+  process.env.VITE_SUPABASE_URL as string,
+  process.env.VITE_SUPABASE_ANON_KEY as string
 );
 
 const app = express();

--- a/services/agent-api/src/supabaseClient.ts
+++ b/services/agent-api/src/supabaseClient.ts
@@ -1,7 +1,7 @@
 import { createClient, SupabaseClient } from '@supabase/supabase-js';
 
-const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL!;
-const supabaseAnonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!;
+const supabaseUrl = process.env.VITE_SUPABASE_URL!;
+const supabaseAnonKey = process.env.VITE_SUPABASE_ANON_KEY!;
 
 export function getSupabaseClient(accessToken?: string): SupabaseClient {
   return createClient(supabaseUrl, supabaseAnonKey, {


### PR DESCRIPTION
## Summary
- update server supabase env vars to use `VITE_` prefix

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6877a74c7628832982037461f86b440f