### PR TITLE
Fix supabase usage in agent-api

### DIFF
--- a/services/agent-api/src/index.ts
+++ b/services/agent-api/src/index.ts
@@ -7,7 +7,7 @@ import path from "path";
 
 import Stripe from "stripe";
 import { agentSchema } from "../../../validation/agentSchema";
-import { createClient } from "@supabase/supabase-js";
+import { getSupabaseClient } from "./supabaseClient";
 import openai from "./openai";
 
 
@@ -65,6 +65,7 @@ app.post("/chat", (req, res) => {
   res.json(message);
 });
 app.post("/register", async (req, res) => {
+  const supabase = getSupabaseClient();
   const { email, password } = req.body;
   const { data, error } = await supabase.auth.signUp({ email, password });
   if (error) return res.status(400).json({ error: error.message });
@@ -72,6 +73,7 @@ app.post("/register", async (req, res) => {
 });
 
 app.post("/login", async (req, res) => {
+  const supabase = getSupabaseClient();
   const { email, password } = req.body;
   const { data, error } = await supabase.auth.signInWithPassword({ email, password });
   if (error) return res.status(400).json({ error: error.message });
@@ -118,6 +120,7 @@ app.post("/generate-ai-agent", async (req, res) => {
 });
 
 app.post("/subscribe", async (req, res) => {
+  const supabase = getSupabaseClient();
   const { userId, priceId } = req.body;
   if (!userId || !priceId) {
     return res.status(400).json({ error: "Missing userId or priceId" });


### PR DESCRIPTION
## Summary
- remove unused `createClient` import and use `getSupabaseClient`
- call `getSupabaseClient()` in register, login and subscribe routes

## Testing
- `npm test`
- `npm run build`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6877b823d4708329babbdce2dbaef8cb