### PR TITLE
Add export-agents endpoint and update gateway

### DIFF
--- a/apps/gateway/index.ts
+++ b/apps/gateway/index.ts
@@ -7,7 +7,7 @@ dotenv.config();
 async function loadSubgraphs() {
   const serviceUrl = process.env.AGENT_SERVICE_URL || 'http://backend:4000';
   try {
-    const res = await fetch(`${serviceUrl}/agents/export`);
+    const res = await fetch(`${serviceUrl}/export-agents`);
     const json = await res.json();
     return (json.data || []) as Array<{ name: string; url: string }>;
   } catch (err) {

--- a/services/agent-api/src/index.ts
+++ b/services/agent-api/src/index.ts
@@ -43,6 +43,20 @@ app.get("/templates", (_req, res) => {
   }
 });
 
+app.get("/export-agents", (_req, res) => {
+  const agentsDir = path.join(__dirname, "../../../apps/backend/src/agents");
+  try {
+    const entries = fs.readdirSync(agentsDir, { withFileTypes: true });
+    const agents = entries
+      .filter((e) => e.isDirectory() && !e.name.startsWith("."))
+      .map((e) => ({ name: e.name, url: `http://${e.name}:4000` }));
+    res.json(agents);
+  } catch (err) {
+    console.error("Failed to load agents", err);
+    res.status(500).json({ error: "Failed to load agents" });
+  }
+});
+
 app.get("/healthz", (_, res) => res.send("OK"));
 app.get("/", (_, res) => res.json({ service: "AgentForgeHQ API" }));
 


### PR DESCRIPTION
## Summary
- expose `/export-agents` route in agent-api to list agent subgraphs
- make gateway request the new endpoint

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6877b821830c832985ba85a71ec0e59c