### PR TITLE
Fix duplicate supabase import

### DIFF
--- a/services/agent-api/src/index.ts
+++ b/services/agent-api/src/index.ts
@@ -9,7 +9,6 @@ import Stripe from "stripe";
 import { agentSchema } from "../../../validation/agentSchema";
 import { getSupabaseClient } from "./supabaseClient";
 import openai from "./openai";
-import { getSupabaseClient } from "./supabaseClient";
 
 
 dotenv.config();


### PR DESCRIPTION
## Summary
- remove second `getSupabaseClient` import from agent-api service

## Testing
- `pnpm --filter agent-api exec tsc --project tsconfig.json --noEmit`

------
https://chatgpt.com/codex/tasks/task_e_6879905bfab883298cb5caadf1185619