### PR TITLE
Add ESLint and Vitest setup

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,3 @@
+eslint.config.js
+scripts/
+**/*.js

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,0 +1,19 @@
+const { FlatCompat } = require('@eslint/eslintrc');
+const js = require('@eslint/js');
+
+const compat = new FlatCompat({
+  baseDirectory: __dirname,
+  recommendedConfig: js.configs.recommended,
+  allConfig: js.configs.all,
+});
+
+module.exports = [
+  { ignores: ['eslint.config.js', 'scripts/**', '**/*.js'] },
+  ...compat.config({
+    extends: ['./packages/eslint-config'],
+    env: { node: true },
+    rules: {
+      '@typescript-eslint/no-explicit-any': 'off',
+    },
+  }),
+];

--- a/package.json
+++ b/package.json
@@ -6,9 +6,16 @@
     "services/*"
   ],
   "scripts": {
-    "lint": "echo \"No lint script defined\"",
+    "lint": "eslint . --ext .ts,.tsx",
     "build": "echo \"No build script defined\"",
-    "test": "echo \"No tests specified\"",
+    "test": "vitest run",
     "export-agents": "node scripts/export-agents.js"
+  },
+  "devDependencies": {
+    "@typescript-eslint/eslint-plugin": "^7.8.0",
+    "@typescript-eslint/parser": "^7.8.0",
+    "eslint": "^9.31.0",
+    "vitest": "^1.5.0",
+    "zod": "^3.25.6"
   }
 }

--- a/tests/agentSchema.test.ts
+++ b/tests/agentSchema.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, it } from 'vitest';
+import { agentSchema } from '../validation/agentSchema';
+
+describe('agentSchema', () => {
+  it('throws when name is missing', () => {
+    expect(() => agentSchema.parse({})).toThrow();
+  });
+
+  it('parses valid input', () => {
+    expect(agentSchema.parse({ name: 'Test' })).toEqual({ name: 'Test' });
+  });
+});


### PR DESCRIPTION
## Summary
- configure ESLint using the workspace eslint-config
- update lint and test scripts
- set up vitest and add a sample test

## Testing
- `pnpm run lint`
- `pnpm run test`


------
https://chatgpt.com/codex/tasks/task_e_68799062057483299375b8e06d7b79f4