### PR TITLE
Add basic backend chat and agents endpoints

### DIFF
--- a/backend/src/routes/agents.ts
+++ b/backend/src/routes/agents.ts
@@ -2,4 +2,11 @@ import { Router } from 'express';
 
 const router = Router();
 
+// Placeholder list endpoint for available agents
+router.get('/list', (_req, res) => {
+  res.json([
+    { id: 1, name: 'Example Agent' }
+  ]);
+});
+
 export default router;

--- a/backend/src/routes/chat.ts
+++ b/backend/src/routes/chat.ts
@@ -2,4 +2,24 @@ import { Router } from 'express';
 
 const router = Router();
 
+interface Message {
+  id: number;
+  content: string;
+}
+
+const messages: Message[] = [];
+let nextId = 1;
+
+// Returns all chat messages
+router.get('/chat', (_req, res) => {
+  res.json(messages);
+});
+
+// Adds a new chat message
+router.post('/chat', (req, res) => {
+  const message: Message = { id: nextId++, content: req.body.content };
+  messages.push(message);
+  res.json(message);
+});
+
 export default router;

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -9,6 +9,7 @@ app.use(express.json());
 
 app.use('/agents', agents);
 app.use('/', chat);
+app.get('/', (_req, res) => res.json({ service: 'AgentForgeHQ backend' }));
 app.get('/healthz', (_req, res) => res.send('OK'));
 
 const port = process.env.PORT || 4000;


### PR DESCRIPTION
## Summary
- implement `/agents/list` that serves sample agents list
- add GET and POST chat routes similar to example API
- expose service root route in Express server

## Testing
- `npm --prefix backend install`
- `npm --prefix backend run build`


------
https://chatgpt.com/codex/tasks/task_e_687990624cf483299f46d78acdc32e19