### PR TITLE
Add basic agents and chat routes

### DIFF
--- a/backend/src/routes/agents.ts
+++ b/backend/src/routes/agents.ts
@@ -2,11 +2,14 @@ import { Router } from 'express';
 
 const router = Router();
 
+const agentsList = [
+  { id: 1, name: 'Example Agent' },
+  { id: 2, name: 'Sample Agent' }
+];
+
 // Placeholder list endpoint for available agents
 router.get('/list', (_req, res) => {
-  res.json([
-    { id: 1, name: 'Example Agent' }
-  ]);
+  res.json(agentsList);
 });
 
 export default router;

--- a/backend/src/routes/chat.ts
+++ b/backend/src/routes/chat.ts
@@ -17,7 +17,8 @@ router.get('/chat', (_req, res) => {
 
 // Adds a new chat message
 router.post('/chat', (req, res) => {
-  const message: Message = { id: nextId++, content: req.body.content };
+  const { content } = req.body;
+  const message: Message = { id: nextId++, content };
   messages.push(message);
   res.json(message);
 });


### PR DESCRIPTION
## Summary
- list agents through `/agents/list`
- handle chat messages with simple in-memory store

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_687999c0861c8329b864408813821151