### PR TITLE
Update compose docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ gateway.
 
 ## Configuration
 
-Copy `.env.example` to `.env` and provide your keys. Docker Compose loads from `.env`, so create it before starting any services. The example file lists all required variables:
+Before running Docker Compose, copy `.env.example` to `.env` and provide your keys. Compose reads from `.env`, so create it prior to starting any services. The example file lists all required variables:
 
 ```bash
 cp .env.example .env


### PR DESCRIPTION
## Summary
- clarify that Docker Compose reads `.env`
- advise copying `.env.example` to `.env` before running

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_687999c466588329adc84257e6bcb763