### PR TITLE
Add SkipTraceEnricher GraphQL entrypoint

### DIFF
--- a/apps/backend/src/agents/SkipTraceEnricher/Dockerfile
+++ b/apps/backend/src/agents/SkipTraceEnricher/Dockerfile
@@ -1,5 +1,5 @@
 FROM node:18-slim
 WORKDIR /app
 COPY . .
-RUN if [ -f package.json ]; then npm install && npm run build; fi
+RUN npm install && npm run build
 CMD ["node", "dist/index.js"]

--- a/apps/backend/src/agents/SkipTraceEnricher/index.ts
+++ b/apps/backend/src/agents/SkipTraceEnricher/index.ts
@@ -1,0 +1,13 @@
+import { ApolloServer } from 'apollo-server';
+import resolvers from './resolvers';
+import { loadSchema } from './tool';
+
+const typeDefs = loadSchema();
+
+const server = new ApolloServer({ typeDefs, resolvers });
+
+const port = process.env.PORT ? Number(process.env.PORT) : 4000;
+
+server.listen({ port }).then(({ url }) => {
+  console.log(`🚀 SkipTraceEnricher ready at ${url}`);
+});

--- a/apps/backend/src/agents/SkipTraceEnricher/package.json
+++ b/apps/backend/src/agents/SkipTraceEnricher/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "skip-trace-enricher",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "ts-node-dev index.ts",
+    "build": "tsc",
+    "start": "node dist/index.js"
+  },
+  "dependencies": {
+    "apollo-server": "latest",
+    "graphql": "latest"
+  },
+  "devDependencies": {
+    "typescript": "latest",
+    "ts-node-dev": "latest",
+    "@types/node": "latest"
+  }
+}

--- a/apps/backend/src/agents/SkipTraceEnricher/tsconfig.json
+++ b/apps/backend/src/agents/SkipTraceEnricher/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../../../../../packages/tsconfig/tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist"
+  },
+  "include": ["*.ts", "*.graphql"]
+}


### PR DESCRIPTION
## Summary
- add a standalone GraphQL server for SkipTraceEnricher agent
- provide package.json and build config
- adjust Dockerfile to install deps and run the compiled server

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_687999f4279c83298ba7e24fc050fc40