### PR TITLE
Unify platform under AgentForge naming and architecture

### DIFF
--- a/docs/AGENTFORGE_PRODUCT_ARCHITECTURE.md
+++ b/docs/AGENTFORGE_PRODUCT_ARCHITECTURE.md
@@ -1,0 +1,158 @@
+# AgentForge Product Architecture
+
+## Product Definition
+
+**AgentForge** is the single product name for the platform that designs, tests, deploys, governs, and improves AI agents.
+
+AgentForge combines four previously separate ideas:
+
+1. **Agent Builder** — visual creation, templates, configuration, tools, knowledge, and testing.
+2. **Agent Runtime** — execution, orchestration, memory, queues, retries, permissions, and deployments.
+3. **Skill System** — reusable workflows, operating procedures, quality gates, and domain capabilities.
+4. **Control Plane** — policies, evaluations, observability, cost controls, audit history, and lifecycle management.
+
+No customer-facing sub-product should compete with the AgentForge name.
+
+## Unified Platform Model
+
+```text
+AgentForge
+├── Studio          Build and configure agents
+├── Playground      Test conversations and workflows
+├── Runtime         Execute agents and tools
+├── Skills          Reusable capabilities and procedures
+├── Registry        Store agents, tools, skills, and templates
+├── Evaluations     Test quality, safety, and reliability
+├── Observability   Logs, traces, metrics, cost, and outcomes
+├── Deployments     Version, release, canary, rollback, scale
+└── Control         Policy, permissions, approvals, and audit
+```
+
+## Agent Hierarchy
+
+Replace the previous Level 1–4 and “GOD-Agent” terminology with production-safe names.
+
+| Tier | Official name | Responsibility |
+|---|---|---|
+| T0 | Tool | One bounded operation such as HTTP, SQL, email, search, or file access |
+| T1 | Specialist Agent | Performs one domain task using approved tools and skills |
+| T2 | Workflow Agent | Coordinates several specialists to complete an end-to-end workflow |
+| T3 | Supervisor Agent | Manages policies, budgets, routing, lifecycle, and escalation |
+
+### Required rules
+
+- Supervisors are internal control-plane actors, not hidden omnipotent agents.
+- Every tier has explicit permissions, budgets, owners, and escalation rules.
+- Human approval is required for destructive, financial, legal, production, or high-impact actions.
+- Agents may invoke only registered tools and downstream agents allowed by policy.
+
+## Context Model
+
+Rename **Context Blueprints** to **Agent Specifications**.
+
+Each versioned Agent Specification should define:
+
+```yaml
+apiVersion: agentforge.dev/v1
+kind: Agent
+metadata:
+  id: buyer-scorer
+  name: Buyer Scorer
+  version: 1.0.0
+spec:
+  tier: specialist
+  purpose: Score buyers against a property and seller strategy.
+  owner: acquisitions
+  model:
+    provider: openai
+    profile: balanced
+  skills:
+    - real-estate-underwriting
+    - buyer-matching
+  tools:
+    - buyer-registry.read
+    - property-records.read
+  memory:
+    mode: scoped
+    retentionDays: 90
+  policies:
+    requireApprovalFor:
+      - external_message
+      - financial_commitment
+  budgets:
+    maxCostPerRunUsd: 1.50
+    maxDurationSeconds: 120
+  evaluationSuite: buyer-scorer-v1
+  escalation:
+    onFailure: deal-workflow-supervisor
+```
+
+## Core Runtime Flow
+
+```text
+User or Event
+     ↓
+AgentForge API
+     ↓
+Policy and Permission Check
+     ↓
+Run Created
+     ↓
+Agent Specification Loaded
+     ↓
+Skills Compiled into Execution Plan
+     ↓
+Tools and Downstream Agents Invoked
+     ↓
+Trace, Cost, Output, and Outcome Recorded
+     ↓
+Evaluation and Approval Gates
+     ↓
+Result Returned or Escalated
+```
+
+## Canonical Monorepo Structure
+
+```text
+apps/
+├── studio/             # customer-facing builder and dashboard
+├── admin/              # internal control plane
+├── playground/         # chat, voice, and workflow testing
+└── docs/               # product and developer documentation
+
+services/
+├── api/                 # public API and authentication boundary
+├── runtime/             # agent execution engine
+├── orchestrator/        # workflow and supervisor coordination
+├── tool-gateway/        # controlled tool execution
+├── evaluator/           # evaluation jobs and scorecards
+└── worker/              # asynchronous jobs and queues
+
+packages/
+├── agent-spec/          # schemas and validators
+├── skill-registry/      # reusable SkillForge-derived skills
+├── tool-registry/       # tool contracts and permissions
+├── prompt-compiler/     # deterministic instruction assembly
+├── policy-engine/       # RBAC, approvals, budgets, restrictions
+├── observability/       # logs, metrics, traces, cost events
+├── sdk/                 # AgentForge SDK
+└── ui/                  # shared design system
+```
+
+## Product Migration
+
+- **AgentForgeHQ** becomes the implementation source for the unified AgentForge platform.
+- **AgentForge** becomes the canonical repository name when the migration is ready.
+- **Creme-AI-Agent-Maker** becomes a historical prototype; reuse its voice/chat and Supabase patterns.
+- **SkillForge** becomes AgentForge Skills, preserving upstream license and attribution where required.
+
+## Product Principles
+
+1. One product name: AgentForge.
+2. Specifications are versioned and validated.
+3. Tools are permissioned, never implicitly available.
+4. Every run is observable and auditable.
+5. Quality is measured through evaluations, not claimed.
+6. Deployment requires rollback and budget controls.
+7. Human approval is a first-class platform feature.
+8. Domain capabilities are packaged as reusable skills.

--- a/docs/NAMING_CONVENTIONS.md
+++ b/docs/NAMING_CONVENTIONS.md
@@ -1,0 +1,276 @@
+# AgentForge Naming Conventions
+
+## Brand Rule
+
+Use **AgentForge** as the only product name.
+
+Do not use these as separate product brands:
+
+- AgentForgeHQ
+- Creme AI Agent Maker
+- SkillForge
+- GOD-Agent
+- Super-Agent
+
+They may appear only in migration history or attribution notes.
+
+## User-Facing Product Areas
+
+| Name | Purpose |
+|---|---|
+| AgentForge Studio | Build and configure agents |
+| AgentForge Playground | Test chat, voice, tools, and workflows |
+| AgentForge Registry | Browse agents, skills, tools, templates, and versions |
+| AgentForge Evaluations | Run test suites and inspect scorecards |
+| AgentForge Deployments | Release, canary, rollback, and scale agents |
+| AgentForge Observability | View runs, traces, logs, outcomes, latency, and cost |
+| AgentForge Control | Manage policies, approvals, permissions, and budgets |
+| AgentForge Skills | Reusable workflow and domain skill library |
+| AgentForge CLI | Local development and operations command line |
+| AgentForge SDK | Programmatic integration package |
+
+## Agent Type Names
+
+Use these official names:
+
+- `tool`
+- `specialist`
+- `workflow`
+- `supervisor`
+
+Avoid exaggerated or ambiguous labels such as `god`, `master`, `ultimate`, `omni`, `brain`, or `hq` in type names.
+
+## Repository Names
+
+Preferred repository pattern:
+
+```text
+agentforge
+agentforge-skills
+agentforge-sdk-js
+agentforge-sdk-python
+agentforge-examples
+agentforge-docs
+agentforge-deploy
+```
+
+For a monorepo, prefer the single canonical repository:
+
+```text
+miamicreme/AgentForge
+```
+
+## Directory Names
+
+Use lowercase kebab-case for directories:
+
+```text
+agent-spec
+skill-registry
+tool-gateway
+policy-engine
+run-history
+cost-controls
+```
+
+Applications and services should describe responsibility rather than technology:
+
+```text
+apps/studio
+apps/playground
+apps/admin
+services/api
+services/runtime
+services/orchestrator
+services/evaluator
+services/worker
+```
+
+Avoid:
+
+```text
+apps/frontend
+apps/backend
+apps/new-ui
+services/misc
+packages/common
+```
+
+## Package Names
+
+Use the `@agentforge` namespace:
+
+```text
+@agentforge/agent-spec
+@agentforge/runtime
+@agentforge/skill-registry
+@agentforge/tool-registry
+@agentforge/policy-engine
+@agentforge/observability
+@agentforge/sdk
+@agentforge/ui
+```
+
+## Database Naming
+
+Use plural snake_case table names:
+
+```text
+organizations
+workspaces
+agents
+agent_versions
+agent_skills
+tools
+agent_tools
+knowledge_sources
+runs
+run_steps
+tool_calls
+evaluation_suites
+evaluation_cases
+evaluation_results
+deployments
+approval_requests
+usage_events
+cost_events
+audit_events
+```
+
+Primary keys use `id`. Foreign keys use `<entity>_id`.
+
+Timestamps use:
+
+```text
+created_at
+updated_at
+started_at
+completed_at
+archived_at
+```
+
+## API Naming
+
+REST resource examples:
+
+```text
+/api/v1/agents
+/api/v1/agents/{agentId}/versions
+/api/v1/runs
+/api/v1/evaluation-suites
+/api/v1/deployments
+/api/v1/approval-requests
+```
+
+Use nouns for resources and verbs only for explicit actions:
+
+```text
+POST /api/v1/agents/{agentId}/runs
+POST /api/v1/deployments/{deploymentId}/rollback
+POST /api/v1/approval-requests/{requestId}/approve
+```
+
+## Event Naming
+
+Use past-tense dotted events:
+
+```text
+agent.created
+agent.version.published
+run.started
+run.step.completed
+tool.call.failed
+evaluation.completed
+deployment.promoted
+approval.requested
+approval.granted
+budget.exceeded
+```
+
+## Environment Variables
+
+Use the `AGENTFORGE_` prefix for platform variables:
+
+```text
+AGENTFORGE_ENV
+AGENTFORGE_API_URL
+AGENTFORGE_LOG_LEVEL
+AGENTFORGE_ENCRYPTION_KEY
+AGENTFORGE_DEFAULT_MODEL
+AGENTFORGE_MAX_RUN_COST_USD
+```
+
+Provider variables retain provider names:
+
+```text
+OPENAI_API_KEY
+ANTHROPIC_API_KEY
+SUPABASE_URL
+SUPABASE_SERVICE_ROLE_KEY
+STRIPE_SECRET_KEY
+```
+
+Never expose secret keys through `VITE_`, `NEXT_PUBLIC_`, or other browser-visible prefixes.
+
+## CLI Naming
+
+The executable is `agentforge` with optional short alias `forge`.
+
+```bash
+agentforge agent create
+agentforge agent run <agent-id>
+agentforge agent validate <agent-id>
+agentforge skill list
+agentforge spec diff <agent-id>
+agentforge eval run <suite-id>
+agentforge deploy create <agent-id>
+agentforge deploy rollback <deployment-id>
+agentforge run logs <run-id>
+agentforge usage report
+```
+
+Mutating commands should support `--dry-run` where practical.
+
+## Versioning
+
+- Platform releases: semantic versioning, such as `v1.4.0`.
+- Agent specifications: semantic versioning per agent.
+- Skills: semantic versioning per skill.
+- APIs: URL major version, such as `/api/v1`.
+- Evaluation suites: immutable versioned IDs, such as `repo-audit-v2`.
+
+## UI Language
+
+Prefer concrete action labels:
+
+- Create agent
+- Test agent
+- Run evaluation
+- Request approval
+- Publish version
+- Deploy agent
+- Roll back deployment
+- View trace
+
+Avoid vague labels:
+
+- Magic build
+- Make smarter
+- Ultimate mode
+- God controls
+- Auto everything
+
+## Migration Mapping
+
+| Previous term | New AgentForge term |
+|---|---|
+| Creme AI Agent Maker | AgentForge Playground prototype |
+| SkillForge | AgentForge Skills |
+| AgentForgeHQ | AgentForge |
+| Context Blueprint | Agent Specification |
+| Primitive Tool / Level 1 | Tool / T0 |
+| Domain Agent / Level 2 | Specialist Agent / T1 |
+| Super-Agent / Level 3 | Workflow Agent / T2 |
+| GOD-Agent / Level 4 | Supervisor Agent / T3 |
+| Omni-Capability Suite | AgentForge capability registry |
+| Bulk Factory | Agent template and provisioning pipeline |

--- a/docs/PRODUCT_IDEAS.md
+++ b/docs/PRODUCT_IDEAS.md
@@ -1,0 +1,233 @@
+# AgentForge Product Ideas
+
+## Highest-Value Product Differentiators
+
+### 1. Agent Specification Compiler
+
+Turn a plain-language request into a validated Agent Specification, tool policy, evaluation suite, and deployment plan.
+
+Example:
+
+> Build an agent that reviews a GitHub repository, fixes build failures, and opens a draft pull request.
+
+AgentForge should generate:
+
+- purpose and boundaries
+- agent tier
+- required skills
+- allowed GitHub tools
+- approval requirements
+- cost and time budgets
+- evaluation cases
+- deployment configuration
+
+### 2. Skill-to-Agent Assembly
+
+AgentForge Skills should behave like installable capabilities rather than prompt snippets.
+
+Each skill should include:
+
+- trigger conditions
+- workflow steps
+- required tools
+- input/output schema
+- permissions
+- evaluation cases
+- evidence requirements
+- version and provenance
+
+### 3. Visual Execution Trace
+
+Show every run as a readable timeline:
+
+```text
+Request received
+→ policy checked
+→ repository inspected
+→ build reproduced
+→ failure localized
+→ patch generated
+→ tests passed
+→ approval requested
+→ draft PR opened
+```
+
+Every step should expose latency, token usage, cost, inputs, outputs, retries, and evidence.
+
+### 4. Approval Inbox
+
+Create a centralized human-in-the-loop queue for actions such as:
+
+- send external email
+- publish content
+- open or merge a pull request
+- deploy to production
+- spend over budget
+- modify financial records
+- delete data
+- contact a customer
+
+Approvers should see the proposed action, reason, evidence, risk, cost, and rollback path.
+
+### 5. Evaluation-First Publishing
+
+An agent cannot be published until its required evaluation suite passes.
+
+Scorecards should cover:
+
+- task success
+- groundedness
+- tool correctness
+- security
+- policy compliance
+- latency
+- cost
+- escalation behavior
+- regression against previous version
+
+### 6. Agent Version Diff
+
+Provide a semantic diff between agent versions:
+
+- instructions changed
+- model changed
+- skills added or removed
+- permissions expanded or reduced
+- budgets changed
+- evaluation score movement
+- expected risk impact
+
+### 7. Cost Guardrails
+
+Support budgets at organization, workspace, agent, deployment, and run levels.
+
+Controls should include:
+
+- maximum cost per run
+- daily and monthly caps
+- model fallback rules
+- maximum tool calls
+- maximum retries
+- timeout limits
+- automatic pause when anomalies appear
+
+### 8. Outcome Learning Loop
+
+Separate agent improvement from uncontrolled self-modification.
+
+AgentForge should:
+
+1. capture traces and outcomes
+2. identify weak runs
+3. generate improvement proposals
+4. test proposals against evaluations
+5. require approval
+6. publish a new version
+7. canary the version
+8. compare outcomes
+
+Agents should never rewrite their production configuration directly.
+
+### 9. Domain Packs
+
+Package complete vertical solutions as AgentForge Packs.
+
+Initial packs:
+
+- Software Engineering Pack
+- Business Operations Pack
+- Real Estate Pack
+- Customer Support Pack
+- Executive Assistant Pack
+- Data and Reporting Pack
+
+A pack may contain agents, skills, tools, templates, evaluations, dashboards, and policies.
+
+### 10. Portable Agent Bundles
+
+Allow exporting an agent as a signed bundle containing:
+
+```text
+agent.yaml
+skills.lock
+tools.policy.yaml
+evaluations/
+README.md
+checksums.json
+```
+
+This enables review, backup, marketplace distribution, and deployment to customer-controlled infrastructure.
+
+## Strong Ideas Recovered from AgentForgeHQ
+
+The following concepts should be retained and modernized:
+
+- hierarchical agent orchestration
+- version-controlled context configuration
+- CLI-based dry runs
+- canary deployments
+- policy linting
+- cost and token reporting
+- continuous evaluation
+- red-team test suites
+- audited configuration changes
+- role-based deploy permissions
+- agent export and container packaging
+
+## Ideas to Change or Avoid
+
+### Hidden omnipotent agents
+
+Replace the hidden “GOD-Agent” idea with a visible, permissioned Supervisor Agent and control plane. Hidden authority creates security, trust, and debugging problems.
+
+### Direct secret exposure
+
+Browser-prefixed environment variables must never contain OpenAI, Stripe, Supabase service-role, or other secret keys.
+
+### Automatic production adaptation
+
+Do not allow an optimizer to modify production prompts or policies without evaluation, approval, versioning, and rollback.
+
+### Multiple competing frontends
+
+Avoid maintaining Next.js frontend, Vite client, admin dashboard, and mobile app before the core product works. Start with Studio and Playground, then add admin and mobile only when justified.
+
+### Technology-first directories
+
+Use responsibility-based boundaries such as `runtime`, `orchestrator`, and `tool-gateway` rather than generic `frontend` and `backend` folders.
+
+## Recommended MVP
+
+The first commercial-quality release should include:
+
+1. organization and workspace accounts
+2. agent template creation
+3. Agent Specification editor
+4. skill and tool selection
+5. chat/workflow playground
+6. versioned agent publishing
+7. run history and visual traces
+8. basic evaluation suites
+9. approval requests
+10. cost and usage dashboard
+11. one deployment target
+12. Software Engineering Agent Pack
+
+## First Flagship Agent
+
+Build the **Repository Delivery Agent** first.
+
+It should:
+
+- inspect a GitHub repository
+- determine how it is meant to run
+- install dependencies safely
+- reproduce failures
+- create a repair plan
+- implement bounded fixes
+- run lint, build, and tests
+- perform production-readiness checks
+- generate evidence
+- open a draft pull request after approval
+
+This agent creates an immediate portfolio demonstration and connects directly to the existing AgentForge Skills work.


### PR DESCRIPTION
## What changed

- Defined AgentForge as the single product name and platform architecture
- Replaced the previous Level 1–4 and GOD-Agent terminology with Tool, Specialist Agent, Workflow Agent, and Supervisor Agent tiers
- Renamed Context Blueprints to versioned Agent Specifications
- Established canonical names for product areas, repositories, packages, database tables, APIs, events, environment variables, and CLI commands
- Consolidated ideas from AgentForgeHQ, Creme AI Agent Maker, AgentForge, and SkillForge
- Added prioritized product opportunities and a focused MVP
- Recommended the Repository Delivery Agent as the first flagship agent

## Why

The existing projects contain complementary ideas but use competing brands, overlapping application boundaries, and terminology that would be difficult to present safely and professionally. These documents establish one coherent AgentForge product model before implementation and repository migration.

## Validation

- Branch is 3 commits ahead and 0 behind main
- Only three new architecture and product documents were added
- No runtime code was changed

## Next implementation step

Use these conventions to rename the monorepo applications and services, create the Agent Specification schema package, and migrate the chat/voice prototype into AgentForge Playground.