### PR TITLE
Define AgentForgeHQ product foundation before implementation

### DIFF
--- a/docs/IMPLEMENTATION_BLUEPRINT.md
+++ b/docs/IMPLEMENTATION_BLUEPRINT.md
@@ -1,0 +1,311 @@
+# AgentForgeHQ Implementation Blueprint
+
+## 1. Delivery strategy
+
+Build one vertical slice first: create a Repository Delivery Agent, test it, evaluate it, publish it, run it against a GitHub repository, and inspect the full execution timeline.
+
+Do not build every product area independently before the first end-to-end workflow works.
+
+## 2. Canonical monorepo structure
+
+```text
+agentforgehq/
+├── apps/
+│   ├── web/                    # AgentForge web application
+│   ├── worker/                 # asynchronous execution workers
+│   └── docs/                   # public documentation site
+├── packages/
+│   ├── agent-spec/             # schema, parser, compiler, semantic diff
+│   ├── agent-runtime/          # execution contracts and state machine
+│   ├── skill-registry/         # skill loading, validation, provenance
+│   ├── tool-registry/          # tool contracts, permissions, adapters
+│   ├── evaluations/            # test cases, scorers, release gates
+│   ├── observability/          # logs, traces, metrics, cost attribution
+│   ├── authz/                  # RBAC and policy decisions
+│   ├── database/               # schema, migrations, typed data access
+│   ├── ui/                     # shared design system
+│   └── config/                 # shared lint, TypeScript, test config
+├── services/
+│   ├── execution-api/          # execution requests and status
+│   ├── tool-gateway/           # controlled tool invocation
+│   └── deployment-controller/  # releases, canaries, rollback
+├── skills/                     # first-party AgentForge Skills
+├── templates/                  # agent templates
+├── evals/                      # canonical evaluation fixtures
+├── infrastructure/             # deployment and environment definitions
+└── docs/
+```
+
+## 3. Recommended stack
+
+### Web
+
+- Next.js with TypeScript
+- React
+- Accessible component system
+- Server actions or typed API client
+- Streaming execution updates
+
+### Data and identity
+
+- PostgreSQL
+- Supabase Auth or equivalent OIDC-compatible provider
+- Row-level tenant isolation where appropriate
+- Object storage for artifacts
+
+### Runtime
+
+- TypeScript services initially
+- Queue-backed execution
+- Sandboxed tool execution
+- OpenTelemetry
+- Provider-agnostic model adapter
+
+### Background work
+
+- Durable queue
+- Bounded retries
+- Dead-letter queue
+- Idempotency keys
+- Execution state machine
+
+### Deployment
+
+- Containers
+- Development, staging, production environments
+- Signed release artifacts
+- Canary rollout
+- Automated rollback hooks
+
+## 4. Core domain model
+
+### Identity and tenancy
+
+- organizations
+- workspaces
+- users
+- memberships
+- roles
+
+### Agent design
+
+- agents
+- agent_drafts
+- agent_specifications
+- agent_releases
+- templates
+- skills
+- skill_versions
+- agent_skill_versions
+- tools
+- tool_versions
+- agent_tool_versions
+
+### Runtime
+
+- executions
+- execution_steps
+- model_calls
+- tool_calls
+- artifacts
+- approvals
+- incidents
+
+### Quality
+
+- evaluation_suites
+- evaluation_cases
+- evaluation_runs
+- evaluation_results
+- release_gates
+
+### Operations
+
+- deployments
+- deployment_events
+- budgets
+- usage_events
+- audit_events
+- secrets
+- policy_decisions
+
+## 5. Execution state machine
+
+```text
+queued
+  -> validating
+  -> awaiting_approval (optional)
+  -> running
+  -> completed
+  -> failed
+  -> cancelled
+```
+
+Each execution step must include:
+
+- unique ID
+- execution ID
+- parent step ID
+- type
+- status
+- started and completed timestamps
+- input and output references
+- model or tool reference
+- token and cost data
+- retry count
+- error classification
+- trace and correlation IDs
+
+## 6. Agent Specification compiler
+
+The compiler converts a user request or template into a validated specification.
+
+Pipeline:
+
+1. Normalize user intent.
+2. Select template and candidate skills.
+3. Generate structured draft.
+4. Validate schema.
+5. Resolve capability dependencies.
+6. Calculate required permissions.
+7. Attach required evaluation suites.
+8. Surface unresolved questions.
+9. Produce immutable candidate specification.
+
+The compiler must never silently grant tools or permissions.
+
+## 7. Tool Gateway
+
+All external actions pass through the Tool Gateway.
+
+Responsibilities:
+
+- validate caller identity
+- validate release and execution state
+- evaluate permission policy
+- resolve secret reference
+- validate input schema
+- enforce rate and budget limits
+- execute tool adapter
+- validate output schema
+- redact sensitive data
+- record trace and audit event
+
+The model never receives raw credentials.
+
+## 8. Evaluation model
+
+Every release declares required gates.
+
+Initial evaluation categories:
+
+- schema validity
+- instruction compliance
+- tool permission enforcement
+- deterministic contract tests
+- regression behavior
+- prompt injection resistance
+- sensitive data handling
+- output quality rubric
+- cost ceiling
+- latency ceiling
+
+A release cannot be published while a required gate is unresolved unless an authorized reviewer records a reasoned override.
+
+## 9. Repository Delivery Agent workflow
+
+```text
+Connect repository
+  -> discover project
+  -> identify run commands
+  -> install dependencies
+  -> build/lint/test
+  -> classify failures
+  -> propose bounded plan
+  -> approval gate
+  -> create branch
+  -> implement changes
+  -> verify
+  -> security/readiness audit
+  -> prepare draft PR
+  -> publish execution report
+```
+
+Required safeguards:
+
+- no direct push to protected branches
+- no secret exfiltration
+- no unrelated refactoring
+- no deletion without explicit scope
+- explicit file-change summary before commit
+- draft PR by default
+
+## 10. Build phases
+
+### Phase 0 — Foundation
+
+- normalize repository structure
+- establish shared configuration
+- add database package
+- create Agent Specification schema
+- create execution contracts
+- set up CI gates
+
+### Phase 1 — Design and test
+
+- AgentForge Studio draft editor
+- Repository Delivery template
+- Skill and Tool Registry basics
+- Playground chat and dry-run
+- specification validation
+
+### Phase 2 — Execute
+
+- queue and worker
+- GitHub read tools
+- execution timeline
+- cost and latency tracking
+- cancellation
+
+### Phase 3 — Govern
+
+- review gates
+- policy decisions
+- GitHub write tools
+- evaluation suites
+- immutable releases
+
+### Phase 4 — Deploy and observe
+
+- release environments
+- deployment status
+- canary and rollback
+- dashboards and incidents
+
+## 11. Definition of done for each slice
+
+A slice is complete only when:
+
+- acceptance criteria are documented
+- tests pass
+- runtime behavior is demonstrated
+- permissions are verified
+- logs and traces are emitted
+- failure handling is tested
+- documentation is updated
+- no unrelated files are changed
+
+## 12. Architecture decisions to record
+
+Create ADRs before implementation for:
+
+1. Runtime orchestration and queue technology
+2. Agent Specification serialization format
+3. Tenant isolation model
+4. Tool sandbox model
+5. Model provider abstraction
+6. Evaluation scorer architecture
+7. Release artifact signing
+8. Secrets management
+9. Event and audit retention
+10. Deployment target

--- a/docs/MIGRATION_PLAN.md
+++ b/docs/MIGRATION_PLAN.md
@@ -1,0 +1,215 @@
+# AgentForgeHQ Repository Consolidation Plan
+
+## Goal
+
+Consolidate the strongest ideas and reusable implementation from AgentForgeHQ, AgentForge, Creme AI Agent Maker, and SkillForge into one coherent AgentForgeHQ product without blindly merging incompatible codebases.
+
+## Source roles
+
+### AgentForgeHQ
+
+Becomes the primary product repository and system of record.
+
+Retain or evaluate:
+
+- monorepo foundation
+- backend agent concepts
+- context/versioning ideas
+- CLI concepts
+- evaluation and optimization concepts
+- agent export concepts
+- CI and containerization work
+
+### AgentForge
+
+Use as a clean-name reference and destination for any concepts that were drafted but not implemented. Do not maintain it as a competing active product repository once consolidation begins.
+
+### Creme AI Agent Maker
+
+Treat as the Playground prototype.
+
+Migrate selectively:
+
+- Supabase client patterns
+- text chat experience
+- browser voice input
+- speech synthesis
+- Edge Function invocation lessons
+- simple responsive UI patterns
+
+Do not copy prototype architecture wholesale.
+
+### SkillForge
+
+Convert into **AgentForge Skills**.
+
+Migrate selectively:
+
+- reusable workflow skills
+- verification gates
+- repository repair workflows
+- production-readiness audits
+- productization workflows
+- upstream attribution and licensing records
+
+Do not expose SkillForge as a separate competing product brand.
+
+## Consolidation rules
+
+1. AgentForgeHQ is the only master brand.
+2. AgentForge is the platform name inside AgentForgeHQ.
+3. No duplicate implementation is retained without an explicit owner and purpose.
+4. Prototype code must pass architecture, security, and dependency review before migration.
+5. Git history and attribution must be preserved where practical.
+6. Secrets and `.env` files must never be migrated.
+7. Every migrated module receives tests and ownership documentation.
+8. Old repositories remain available until the replacement workflow is verified.
+
+## Migration sequence
+
+### Step 1 — Inventory
+
+For every source repository, record:
+
+- active applications
+- packages and services
+- runtime dependencies
+- database dependencies
+- external integrations
+- environment variables
+- tests
+- deployment files
+- useful documentation
+- stale or duplicate components
+
+### Step 2 — Classify
+
+Classify each asset as:
+
+- migrate
+- rewrite
+- reference only
+- archive
+- delete after verification
+
+### Step 3 — Establish destination contracts
+
+Before moving code, implement or document:
+
+- package boundaries
+- Agent Specification schema
+- tool contract
+- skill contract
+- execution contract
+- evaluation contract
+- audit event contract
+
+### Step 4 — Migrate Playground
+
+Move the useful chat and voice experience into `apps/web` under AgentForge Playground.
+
+Required improvements:
+
+- authenticated workspace context
+- streaming responses
+- execution ID and status
+- cancellation
+- tool-call visualization
+- error states
+- accessibility
+- no client-side secret handling
+
+### Step 5 — Migrate skills
+
+Create `skills/` and `packages/skill-registry`.
+
+Each skill must include:
+
+- name and version
+- description and triggers
+- input and output contracts
+- required tools
+- requested permissions
+- workflow steps
+- evaluation suite references
+- provenance and license metadata
+
+### Step 6 — Normalize runtime
+
+Replace overlapping backend paths with a single execution architecture:
+
+- execution API
+- durable queue
+- worker
+- Tool Gateway
+- model adapter
+- execution timeline
+
+### Step 7 — Archive legacy identities
+
+After replacement capabilities are verified:
+
+- update old READMEs with migration notices
+- link to AgentForgeHQ
+- mark repositories archived where appropriate
+- preserve license and attribution notices
+- disable obsolete deployments and secrets
+
+## Naming migration
+
+| Existing name | Destination |
+|---|---|
+| AgentForgeHQ | AgentForgeHQ master brand and repository |
+| AgentForge | AgentForge platform |
+| Creme AI Agent Maker | AgentForge Playground prototype |
+| SkillForge | AgentForge Skills |
+| Context Blueprint | Agent Specification |
+| GOD-Agent | Supervisor Agent |
+| Super-Agent | Coordinator Agent |
+| Domain Agent | Specialist Agent |
+| Primitive Wrapper | Tool |
+| Bulk Factory | Agent Provisioning Pipeline |
+| Omni-Capability Suite | Capability Registry |
+
+## Repository cleanup targets
+
+The current AgentForgeHQ structure should ultimately eliminate overlapping or ambiguous roots such as separate `client` and `backend` folders outside the canonical workspaces unless they have a documented transitional purpose.
+
+Target active roots:
+
+```text
+apps/
+packages/
+services/
+skills/
+templates/
+evals/
+infrastructure/
+docs/
+```
+
+## Verification gates
+
+A migration unit is accepted only when:
+
+- destination build passes
+- tests pass
+- behavior is demonstrated
+- secrets scan passes
+- dependency scan passes
+- documentation exists
+- source and attribution are recorded
+- old path is not removed until replacement is confirmed
+
+## Decommission checklist
+
+Before archiving a source repository:
+
+- all retained assets are migrated or documented
+- active deployments are identified
+- DNS and environment dependencies are resolved
+- secrets are rotated or revoked
+- users are redirected
+- README contains migration status
+- final tag or release is created
+- repository is set read-only or archived

--- a/docs/PRD_V1.md
+++ b/docs/PRD_V1.md
@@ -1,0 +1,256 @@
+# AgentForgeHQ v1 Product Requirements Document
+
+## 1. Objective
+
+Deliver a production-minded MVP that lets a user create, test, evaluate, and publish a governed AI agent from one platform.
+
+The MVP must prove one complete lifecycle rather than expose a large collection of disconnected screens.
+
+## 2. MVP success criteria
+
+A user can:
+
+1. Create a workspace.
+2. Create an agent from a template or plain-language description.
+3. Review and edit the generated Agent Specification.
+4. Attach approved skills and tools.
+5. Test the agent in AgentForge Playground.
+6. Inspect an execution timeline with model and tool steps.
+7. Run a required evaluation suite.
+8. Resolve failures or request a review override.
+9. Publish an immutable release.
+10. View deployment status, cost, latency, and outcome metrics.
+
+## 3. Flagship template
+
+### Repository Delivery Agent
+
+The first fully supported template will:
+
+- Connect to a GitHub repository
+- Read repository metadata and files
+- Detect project structure and run instructions
+- Attempt installation, build, lint, and tests
+- Localize failures
+- Produce a bounded repair plan
+- Make approved changes on a branch
+- Re-run verification
+- Perform security and production-readiness checks
+- Open a draft pull request
+- Generate an auditable execution timeline
+
+## 4. Core personas
+
+### Builder
+Creates and configures agents, skills, tools, evaluations, and releases.
+
+### Reviewer
+Approves specifications, permissions, evaluation exceptions, and deployments.
+
+### Operator
+Monitors executions, incidents, costs, deployment health, and rollbacks.
+
+### Administrator
+Manages organizations, access, secrets, policy, billing, and platform settings.
+
+## 5. Functional requirements
+
+### 5.1 AgentForge Studio
+
+- Create agent from template
+- Create agent from plain-language request
+- Edit structured Agent Specification
+- Configure model and runtime settings
+- Attach skills, tools, memory, and policies
+- Show unresolved validation issues
+- Save drafts automatically
+- Create a versioned candidate release
+
+### 5.2 Agent Specification
+
+Required fields:
+
+- identity
+- purpose
+- responsibilities
+- forbidden actions
+- input schema
+- output schema
+- instruction set
+- capability set
+- tool permissions
+- memory profile
+- escalation policy
+- budget policy
+- evaluation requirements
+- observability requirements
+- version metadata
+
+The specification must validate against a versioned schema.
+
+### 5.3 AgentForge Registry
+
+- Browse agents, skills, tools, templates, and releases
+- Display provenance and ownership
+- Show dependency graph
+- Show permission requirements
+- Show compatibility status
+- Support immutable published versions
+- Support deprecation without silent deletion
+
+### 5.4 AgentForge Playground
+
+- Text chat
+- Voice input where supported
+- Streaming output
+- Tool-call visualization
+- Dry-run mode
+- Test input library
+- Side-by-side release comparison
+- Stop execution control
+- User feedback capture
+
+### 5.5 AgentForge Evaluations
+
+- Static specification validation
+- Deterministic contract tests
+- Tool permission tests
+- Safety and policy tests
+- Quality rubric scoring
+- Regression test suites
+- Red-team prompts
+- Release pass/fail decision
+- Human override with reason and audit entry
+
+### 5.6 AgentForge Control
+
+- Organization and workspace roles
+- Tool-level permissions
+- Secret references, never exposed raw in prompts
+- Budget limits by organization, workspace, agent, and execution
+- Approval policies
+- High-impact action review gates
+- Emergency disable switch
+- Full audit history
+
+### 5.7 AgentForge Deployments
+
+- Publish immutable release
+- Environment promotion: development, staging, production
+- Canary rollout
+- Rollback
+- Deployment status
+- Health checks
+- Release notes
+- Approval record
+
+### 5.8 AgentForge Observe
+
+- Execution count
+- Success and failure rate
+- p50/p95 latency
+- Token and model cost
+- Tool-call count and failures
+- Evaluation score trends
+- User feedback
+- Business outcome metrics
+- Execution timeline
+- Incident records
+
+### 5.9 AgentForge CLI
+
+Initial commands:
+
+```text
+forge auth login
+forge agent create
+forge agent validate
+forge agent run
+forge agent release
+forge agent deploy
+forge agent logs
+forge agent disable
+forge spec diff
+forge eval run
+forge cost report
+```
+
+Mutating commands must support `--dry-run` where practical.
+
+## 6. Non-functional requirements
+
+### Security
+
+- Least privilege
+- Tenant isolation
+- Encrypted secrets
+- Signed release artifacts
+- Audit log integrity
+- Input and output validation
+- Rate limits
+- Dependency and image scanning
+
+### Reliability
+
+- Idempotent execution steps where possible
+- Retry policy with bounded attempts
+- Dead-letter handling for failed asynchronous work
+- Deployment rollback
+- Health checks and readiness checks
+
+### Observability
+
+- Structured logs
+- Correlation IDs
+- Distributed traces
+- RED metrics for services
+- Cost attribution by execution
+
+### Accessibility
+
+- WCAG 2.1 AA target
+- Keyboard operability
+- Screen-reader labels
+- Sufficient contrast
+- Reduced-motion support
+
+### Performance targets
+
+- Studio page interactive in under 3 seconds on a typical broadband connection
+- Non-model API p95 under 500 ms
+- Execution status updates visible within 2 seconds
+- Agent specification validation under 1 second for typical documents
+
+## 7. Out of scope for v1
+
+- Fully autonomous self-modification
+- Public marketplace payments
+- Native mobile applications
+- General-purpose visual workflow canvas
+- Arbitrary code execution without sandboxing
+- Unlimited multi-agent recursion
+- Automatic production deployment without a policy decision
+
+## 8. Release gates
+
+The MVP is releasable only when:
+
+- The flagship workflow succeeds end to end
+- Tenant isolation tests pass
+- Required evaluation gates work
+- Execution timelines are complete
+- Budget enforcement works
+- A failed deployment can be rolled back
+- No secret values appear in application logs or model prompts
+- Setup and operator documentation are complete
+
+## 9. Product metrics
+
+- Time from agent creation to first successful test
+- Percentage of agents passing evaluations on first attempt
+- Execution success rate
+- Average cost per successful execution
+- Time to diagnose a failed run
+- Release rollback frequency
+- User satisfaction per agent execution
+- Number of reusable skills adopted across multiple agents

--- a/docs/PRODUCT_VISION.md
+++ b/docs/PRODUCT_VISION.md
@@ -1,0 +1,93 @@
+# AgentForgeHQ Product Vision
+
+## Product statement
+
+**AgentForgeHQ is the command center for building, testing, deploying, governing, and improving production AI agents.**
+
+AgentForgeHQ is the master brand and operating environment. AgentForge is the platform experience inside it.
+
+## Problem
+
+Teams can prototype AI assistants quickly, but production agents require much more than prompts. They need versioned specifications, tool permissions, evaluations, cost controls, human approvals, deployment workflows, traceability, and operational visibility.
+
+Today those capabilities are fragmented across prompt editors, orchestration frameworks, observability tools, secrets managers, and deployment systems.
+
+## Vision
+
+AgentForgeHQ brings the entire lifecycle into one governed system:
+
+1. Define an agent in plain language.
+2. Compile that intent into a versioned Agent Specification.
+3. Attach skills, tools, memory, policies, and evaluation suites.
+4. Test the agent in a safe playground.
+5. Review execution traces and quality scores.
+6. Publish through approval and deployment gates.
+7. Monitor cost, latency, tool use, outcomes, and incidents.
+8. Improve using controlled, reviewable optimization loops.
+
+## Target users
+
+### Primary
+
+- AI application engineers
+- Software teams adding agentic workflows
+- Solutions architects
+- Automation consultants
+- Technical founders
+
+### Secondary
+
+- Operations leaders
+- Compliance teams
+- Product managers
+- Domain experts who configure agents without writing runtime code
+
+## Core promise
+
+AgentForgeHQ does not merely generate agents. It produces **controlled, observable, testable, and deployable agent systems**.
+
+## Differentiators
+
+- Specification-first agent creation
+- Reusable skills and capability packs
+- Evaluation-required publishing
+- Visual execution timelines
+- Human review gates
+- Fine-grained budgets and permissions
+- Versioned releases with semantic diffs
+- Portable Agent Packages
+- Controlled multi-agent orchestration
+- Production-readiness standards built into the workflow
+
+## Product principles
+
+1. **No invisible power** — every meaningful action is attributable and auditable.
+2. **No deploy without proof** — publishing requires passing evaluations and explicit policy checks.
+3. **Least privilege by default** — tools and data access are narrowly scoped.
+4. **Human authority remains explicit** — high-impact actions require review gates.
+5. **Version everything** — specifications, skills, tools, evaluations, and releases are immutable once published.
+6. **Observe outcomes, not just prompts** — the system measures success, cost, latency, and business results.
+7. **Portable by design** — agents can be exported as signed packages with declared dependencies.
+
+## Brand architecture
+
+- **AgentForgeHQ** — company, ecosystem, and command-center brand
+- **AgentForge** — primary platform
+- **AgentForge Studio** — visual builder
+- **AgentForge Playground** — interactive test environment
+- **AgentForge Registry** — agents, skills, tools, templates, and releases
+- **AgentForge Evaluations** — tests, scorecards, and red-team checks
+- **AgentForge Deployments** — publishing, rollout, scaling, and rollback
+- **AgentForge Observe** — logs, traces, cost, latency, and outcomes
+- **AgentForge Control** — policies, approvals, budgets, and access
+- **AgentForge Skills** — reusable workflows and domain capability packs
+- **AgentForge CLI** — developer command line
+- **AgentForge SDK** — programmatic integration layer
+
+## Flagship experience
+
+The first flagship agent is the **Repository Delivery Agent**. It connects to GitHub, scans a repository, reproduces failures, proposes a bounded repair plan, performs changes, runs verification, conducts a production-readiness review, and opens a draft pull request with a complete execution timeline.
+
+## Long-term direction
+
+AgentForgeHQ becomes the system of record for enterprise AI agents: what they are allowed to do, how they were tested, what version is deployed, what they cost, what tools they used, what outcomes they produced, and who approved them.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,0 +1,221 @@
+# AgentForgeHQ Roadmap
+
+## Delivery rule
+
+Every phase must produce one demonstrable vertical slice. Documentation, contracts, tests, implementation, observability, and operating instructions move together.
+
+## Phase 0 — Product foundation
+
+### Objective
+
+Agree on what AgentForgeHQ is before restructuring or adding runtime code.
+
+### Deliverables
+
+- Product vision
+- v1 PRD
+- Product architecture
+- Naming conventions
+- Implementation blueprint
+- Repository consolidation plan
+- Initial architecture decision record list
+- Canonical documentation index
+
+### Exit criteria
+
+- One master brand and product vocabulary
+- One MVP workflow
+- One canonical repository structure
+- Clear in-scope and out-of-scope boundaries
+
+## Phase 1 — Specification foundation
+
+### Objective
+
+Represent an agent as a validated, versioned contract.
+
+### Deliverables
+
+- `packages/agent-spec`
+- Agent Specification JSON Schema
+- TypeScript types and validators
+- Example Repository Delivery specification
+- Semantic specification diff
+- Validation CLI
+- Unit and contract tests
+
+### Exit criteria
+
+- Invalid specifications fail predictably
+- Permissions and required evaluations are explicit
+- A candidate specification can be compiled from a template
+
+## Phase 2 — Studio and Playground
+
+### Objective
+
+Create and test an agent without deploying it.
+
+### Deliverables
+
+- AgentForge Studio agent editor
+- Template selection
+- AgentForge Playground
+- Text and voice interaction
+- Dry-run mode
+- Execution status and cancellation
+- Initial execution timeline
+
+### Exit criteria
+
+- User can create and test the Repository Delivery Agent
+- No model or provider secrets are exposed to the browser
+- Failures are visible and actionable
+
+## Phase 3 — Skills and tools
+
+### Objective
+
+Attach reusable capabilities through governed contracts.
+
+### Deliverables
+
+- Skill Registry
+- Tool Registry
+- Tool Gateway
+- GitHub read-only connector
+- AgentForge Skills packaging format
+- Provenance and license fields
+- Permission evaluation
+
+### Exit criteria
+
+- Skills declare dependencies and required permissions
+- All tool calls are logged and traceable
+- Unauthorized calls are blocked before execution
+
+## Phase 4 — Durable execution
+
+### Objective
+
+Run multi-step work reliably.
+
+### Deliverables
+
+- Execution API
+- Queue and workers
+- Execution state machine
+- Retry and dead-letter handling
+- Cost accounting
+- Structured logging and traces
+- Artifact storage
+
+### Exit criteria
+
+- Executions survive worker restarts
+- Steps are correlated end to end
+- Duplicate requests do not create duplicate irreversible actions
+
+## Phase 5 — Evaluations and review gates
+
+### Objective
+
+Require proof before release.
+
+### Deliverables
+
+- Evaluation Suite model
+- Deterministic tests
+- Policy and security checks
+- Regression suite
+- Human approval inbox
+- Override reasons and audit events
+- Release gate engine
+
+### Exit criteria
+
+- Required failures prevent publishing
+- Overrides require authorization and explanation
+- Results are attached to a specific candidate release
+
+## Phase 6 — Repository Delivery Agent
+
+### Objective
+
+Complete the flagship GitHub workflow.
+
+### Deliverables
+
+- Repository discovery
+- Install/build/lint/test execution
+- Failure classification
+- Bounded repair plan
+- Approval gate
+- GitHub branch and draft PR creation
+- Production-readiness report
+- Complete execution timeline
+
+### Exit criteria
+
+- Works end to end on at least three representative repositories
+- Never pushes directly to protected branches
+- Produces a reviewable draft PR with evidence
+
+## Phase 7 — Releases and deployment
+
+### Objective
+
+Publish immutable, governed agent releases.
+
+### Deliverables
+
+- Candidate and published releases
+- Development, staging, production environments
+- Deployment controller
+- Canary rollout
+- Rollback
+- Signed Agent Packages
+- Release notes
+
+### Exit criteria
+
+- Published releases are immutable
+- Rollback is tested
+- Deployment status is visible
+
+## Phase 8 — Observe and optimize
+
+### Objective
+
+Measure real outcomes and improve safely.
+
+### Deliverables
+
+- AgentForge Observe dashboards
+- Cost, latency, and success trends
+- Feedback capture
+- Incident workflow
+- Controlled optimization proposals
+- A/B release comparison
+
+### Exit criteria
+
+- Every production execution has cost and outcome attribution
+- Optimization proposals require evaluation and review
+- No autonomous production self-modification
+
+## Post-v1 opportunities
+
+- Business Operations Pack
+- Real Estate Pack
+- Customer Support Pack
+- Data Engineering Pack
+- Career Pack
+- Public skill marketplace
+- Enterprise SSO and SCIM
+- Bring-your-own-cloud deployment
+- Native mobile operator experience
+
+## Immediate next milestone
+
+Implement Phase 1 only after the documentation pull request is reviewed. The first code change should create the Agent Specification package and its tests, not reorganize the entire monorepo at once.


### PR DESCRIPTION
## Summary

This documentation-first change turns the AgentForgeHQ concept into an executable product foundation before runtime code is modified.

## Added

- `docs/PRODUCT_VISION.md`
  - Defines AgentForgeHQ as the master brand and AgentForge as the platform
  - Establishes product principles, target users, differentiators, and flagship experience

- `docs/PRD_V1.md`
  - Defines the first complete MVP lifecycle
  - Specifies Studio, Playground, Registry, Evaluations, Control, Deployments, Observe, and CLI requirements
  - Sets security, reliability, accessibility, performance, and release gates

- `docs/IMPLEMENTATION_BLUEPRINT.md`
  - Defines the target monorepo structure, domain model, execution state machine, Tool Gateway, Agent Specification compiler, and phased implementation

- `docs/MIGRATION_PLAN.md`
  - Consolidates AgentForgeHQ, AgentForge, Creme AI Agent Maker, and SkillForge without blindly merging incompatible code
  - Defines migration, attribution, cleanup, verification, and decommission rules

- `docs/ROADMAP.md`
  - Defines phases from product foundation through specification, Playground, skills, durable execution, evaluations, flagship agent, deployment, and optimization

## Product decision

- **AgentForgeHQ** remains the master brand and command center
- **AgentForge** is the platform inside it
- **AgentForge Skills** absorbs SkillForge capabilities
- **AgentForge Playground** absorbs the useful Creme AI Agent Maker prototype
- The first flagship workflow is the **Repository Delivery Agent**

## Why this is stacked

This branch is based on `agent/unify-agentforge-naming`, which contains the naming and architecture normalization work. Keeping this PR stacked isolates the expanded product foundation from the naming PR.

## Validation

- Documentation-only change
- No runtime code changed
- No existing files deleted or rewritten
- Each document defines explicit scope, boundaries, and exit criteria

## Next step after review

Implement `packages/agent-spec` with a versioned Agent Specification schema, validators, semantic diff, examples, and tests. Do not begin with a broad monorepo rewrite.