### PR TITLE
Harden AgentForgeHQ days 1–7 with twenty audit passes

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,15 @@
+version: 2
+updates:
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+    groups:
+      development-dependencies:
+        dependency-type: development
+        update-types:
+          - minor
+          - patch
+    commit-message:
+      prefix: deps

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches: [main, 'agent/**']
   pull_request:
+  workflow_dispatch:
 
 permissions:
   contents: read
@@ -28,11 +29,14 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 20.11.1
           cache: pnpm
 
       - name: Install dependencies
         run: pnpm install --no-frozen-lockfile
+
+      - name: Foundation audit
+        run: pnpm audit:foundation
 
       - name: Format
         run: pnpm format:check

--- a/docs/DAYS_1_7_TWENTY_PASS_AUDIT.md
+++ b/docs/DAYS_1_7_TWENTY_PASS_AUDIT.md
@@ -1,0 +1,49 @@
+# AgentForgeHQ Days 1–7 — Twenty-Pass Hardening Audit
+
+## Scope
+
+This audit revisits the product and engineering foundation delivered during Days 1–7. It does not expand the MVP into later runtime features. It strengthens the baseline that later phases depend on.
+
+## Twenty passes
+
+1. **MVP boundary pass** — confirmed the golden path and deferred-scope boundaries remain consistent with the product foundation.
+2. **Repository identity pass** — confirmed the root package is private and named `agentforgehq`.
+3. **Runtime version pass** — pinned CI to Node 20.11.1 and pnpm 9.15.4.
+4. **Workspace topology pass** — verified the canonical `apps/*`, `packages/*`, and `services/*` workspace patterns.
+5. **CI trigger pass** — added manual `workflow_dispatch` while retaining branch and pull-request verification.
+6. **CI gate pass** — added an executable foundation audit before formatting, linting, type checking, tests, and build.
+7. **Dependency maintenance pass** — added grouped weekly Dependabot updates with a bounded PR limit.
+8. **Secret exposure pass** — added checks that reject service-role, OpenAI, and Stripe secrets exposed through browser-prefixed environment variables.
+9. **Required-file pass** — added deterministic checks for the minimum foundation file set.
+10. **Schema strictness pass** — made nested Agent Specification objects strict, not only the top-level object.
+11. **Input normalization pass** — trims human-entered strings before validation and compilation.
+12. **Duplicate capability pass** — deduplicates skills, tools, approval requirements, success criteria, and system instructions.
+13. **Numeric integrity pass** — rejects non-finite cost and evaluation score values.
+14. **Execution-limit coherence pass** — prevents maximum tool calls from exceeding maximum total steps.
+15. **Compiler determinism pass** — verifies ordering changes in skills and tools do not alter compiled output.
+16. **Semantic-diff stability pass** — preserves stable top-level semantic change paths.
+17. **Authorization vocabulary pass** — added explicit approval and evaluation actions to the workspace permission model.
+18. **Authorization runtime-boundary pass** — added role/action guards and blank identifier rejection.
+19. **Authorization matrix pass** — expanded tests for owner, builder, reviewer, and viewer boundaries.
+20. **Database tenant-integrity pass** — added triggers preventing cross-workspace agent versions, mismatched current versions, and mutation of version identity fields.
+
+## Concrete changes
+
+- Hardened `packages/agent-spec` validation and tests.
+- Hardened `packages/auth` permissions, runtime guards, and tests.
+- Added `scripts/foundation-audit.mjs` and wired it into `pnpm verify` and CI.
+- Added weekly Dependabot configuration.
+- Added `202607170005_foundation_integrity.sql` for relational and tenant consistency.
+- Added explicit update and delete policies where the foundation previously lacked them.
+
+## Evidence status
+
+The source changes, tests, workflow definitions, and migrations are present on the branch. The GitHub connector cannot execute package installation, TypeScript compilation, unit tests, or Supabase migrations locally. CI and database execution evidence remain required before merge.
+
+## Remaining blockers
+
+1. Generate and commit `pnpm-lock.yaml`, then restore frozen installs.
+2. Confirm a compatible ESLint flat configuration exists and passes.
+3. Run all migrations against a disposable Supabase project.
+4. Add automated cross-workspace RLS integration tests.
+5. Confirm the intended organization/workspace bootstrap path, since tenant creation should not rely on unrestricted client-side inserts.

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "node": ">=20.11.0"
   },
   "scripts": {
+    "audit:foundation": "node scripts/foundation-audit.mjs",
     "build": "pnpm -r --if-present run build",
     "clean": "pnpm -r --if-present run clean",
     "format:check": "prettier --check .",
@@ -14,7 +15,7 @@
     "test": "pnpm -r --if-present run test",
     "test:coverage": "pnpm -r --if-present run test:coverage",
     "typecheck": "pnpm -r --if-present run typecheck",
-    "verify": "pnpm format:check && pnpm lint && pnpm typecheck && pnpm test && pnpm build",
+    "verify": "pnpm audit:foundation && pnpm format:check && pnpm lint && pnpm typecheck && pnpm test && pnpm build",
     "export-agents": "node scripts/export-agents.js"
   },
   "devDependencies": {

--- a/packages/agent-spec/src/index.ts
+++ b/packages/agent-spec/src/index.ts
@@ -1,52 +1,63 @@
 import { z } from 'zod'
 
-const Identifier = z.string().regex(/^[a-z0-9]+(?:-[a-z0-9]+)*$/)
+const Identifier = z.string().trim().regex(/^[a-z0-9]+(?:-[a-z0-9]+)*$/)
+const NonBlank = (min: number, max: number) => z.string().trim().min(min).max(max)
+const UniqueIdentifiers = z.array(Identifier).max(50).transform((items) => [...new Set(items)])
 
 export const AgentSpecificationSchema = z
   .object({
     schemaVersion: z.literal('1.0'),
     identity: z.object({
-      name: z.string().min(2).max(120),
+      name: NonBlank(2, 120),
       slug: Identifier,
-      description: z.string().min(10).max(500),
+      description: NonBlank(10, 500),
       type: z.enum(['specialist', 'workflow', 'supervisor']),
-    }),
+    }).strict(),
     objective: z.object({
-      primary: z.string().min(10).max(1000),
-      successCriteria: z.array(z.string().min(3)).min(1).max(20),
-    }),
+      primary: NonBlank(10, 1000),
+      successCriteria: z.array(NonBlank(3, 300)).min(1).max(20).transform((items) => [...new Set(items)]),
+    }).strict(),
     instructions: z.object({
-      system: z.array(z.string().min(3)).min(1).max(50),
-    }),
-    skills: z.array(Identifier).max(50).default([]),
+      system: z.array(NonBlank(3, 1000)).min(1).max(50).transform((items) => [...new Set(items)]),
+    }).strict(),
+    skills: UniqueIdentifiers.default([]),
     tools: z.object({
-      allowed: z.array(Identifier).max(50).default([]),
-      forbidden: z.array(Identifier).max(50).default([]),
-    }),
+      allowed: UniqueIdentifiers.default([]),
+      forbidden: UniqueIdentifiers.default([]),
+    }).strict(),
     limits: z.object({
       maximumSteps: z.number().int().positive().max(500).default(50),
       maximumToolCalls: z.number().int().nonnegative().max(500).default(30),
-      maximumCostUsd: z.number().nonnegative().max(1000).default(5),
+      maximumCostUsd: z.number().finite().nonnegative().max(1000).default(5),
       executionTimeoutSeconds: z.number().int().positive().max(86_400).default(900),
-    }),
+    }).strict(),
     approvalPolicy: z.object({
       requiredFor: z.array(
         z.enum(['file_write', 'command_execution', 'pull_request_creation', 'external_message', 'deployment']),
-      ),
-    }),
+      ).transform((items) => [...new Set(items)]),
+    }).strict(),
     evaluationPolicy: z.object({
       requiredSuite: Identifier,
-      minimumScore: z.number().min(0).max(1),
-    }),
+      minimumScore: z.number().finite().min(0).max(1),
+    }).strict(),
   })
   .strict()
   .superRefine((spec, ctx) => {
-    const overlap = spec.tools.allowed.filter((tool) => spec.tools.forbidden.includes(tool))
-    for (const tool of overlap) {
+    const forbidden = new Set(spec.tools.forbidden)
+    for (const tool of spec.tools.allowed) {
+      if (forbidden.has(tool)) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: ['tools', 'allowed'],
+          message: `Tool '${tool}' cannot be both allowed and forbidden`,
+        })
+      }
+    }
+    if (spec.limits.maximumToolCalls > spec.limits.maximumSteps) {
       ctx.addIssue({
         code: z.ZodIssueCode.custom,
-        path: ['tools', 'allowed'],
-        message: `Tool '${tool}' cannot be both allowed and forbidden`,
+        path: ['limits', 'maximumToolCalls'],
+        message: 'maximumToolCalls cannot exceed maximumSteps',
       })
     }
   })

--- a/packages/agent-spec/test/agent-spec.test.ts
+++ b/packages/agent-spec/test/agent-spec.test.ts
@@ -45,24 +45,57 @@ describe('AgentSpecification', () => {
     expect(AgentSpecificationSchema.parse(validSpec).identity.slug).toBe('repository-delivery-agent')
   })
 
-  it('rejects unknown top-level fields', () => {
+  it('rejects unknown fields at nested boundaries', () => {
     expect(() => AgentSpecificationSchema.parse({ ...validSpec, secret: 'nope' })).toThrow()
+    expect(() => AgentSpecificationSchema.parse({ ...validSpec, identity: { ...validSpec.identity, secret: 'nope' } })).toThrow()
   })
 
   it('rejects tools that are both allowed and forbidden', () => {
-    expect(() =>
-      AgentSpecificationSchema.parse({
-        ...validSpec,
-        tools: { allowed: ['github-read'], forbidden: ['github-read'] },
-      }),
-    ).toThrow(/both allowed and forbidden/)
+    expect(() => AgentSpecificationSchema.parse({
+      ...validSpec,
+      tools: { allowed: ['github-read'], forbidden: ['github-read'] },
+    })).toThrow(/both allowed and forbidden/)
   })
 
-  it('compiles deterministically regardless of skill ordering', () => {
+  it('rejects tool-call limits that exceed total steps', () => {
+    expect(() => AgentSpecificationSchema.parse({
+      ...validSpec,
+      limits: { ...validSpec.limits, maximumSteps: 5, maximumToolCalls: 6 },
+    })).toThrow(/cannot exceed maximumSteps/)
+  })
+
+  it('normalizes whitespace and removes duplicate capabilities', () => {
+    const parsed = AgentSpecificationSchema.parse({
+      ...validSpec,
+      identity: { ...validSpec.identity, name: '  Repository Delivery Agent  ' },
+      skills: ['repository-inspection', 'repository-inspection'],
+      tools: { ...validSpec.tools, allowed: ['github-read', 'github-read'] },
+    })
+    expect(parsed.identity.name).toBe('Repository Delivery Agent')
+    expect(parsed.skills).toEqual(['repository-inspection'])
+    expect(parsed.tools.allowed).toEqual(['github-read'])
+  })
+
+  it('rejects non-finite money and score values', () => {
+    expect(() => AgentSpecificationSchema.parse({
+      ...validSpec,
+      limits: { ...validSpec.limits, maximumCostUsd: Number.NaN },
+    })).toThrow()
+    expect(() => AgentSpecificationSchema.parse({
+      ...validSpec,
+      evaluationPolicy: { ...validSpec.evaluationPolicy, minimumScore: Number.POSITIVE_INFINITY },
+    })).toThrow()
+  })
+
+  it('compiles deterministically regardless of capability ordering', () => {
     const first = compileAgentSpecification(validSpec)
     const second = compileAgentSpecification({
       ...validSpec,
       skills: [...validSpec.skills].reverse(),
+      tools: {
+        allowed: [...validSpec.tools.allowed].reverse(),
+        forbidden: [...validSpec.tools.forbidden].reverse(),
+      },
     })
     expect(first).toEqual(second)
   })
@@ -72,12 +105,10 @@ describe('AgentSpecification', () => {
       ...validSpec,
       limits: { ...validSpec.limits, maximumCostUsd: 10 },
     })
-    expect(changes).toEqual([
-      {
-        path: 'limits',
-        before: validSpec.limits,
-        after: { ...validSpec.limits, maximumCostUsd: 10 },
-      },
-    ])
+    expect(changes).toEqual([{
+      path: 'limits',
+      before: validSpec.limits,
+      after: { ...validSpec.limits, maximumCostUsd: 10 },
+    }])
   })
 })

--- a/packages/auth/src/index.ts
+++ b/packages/auth/src/index.ts
@@ -9,14 +9,24 @@ export const WorkspaceActions = [
   'agent:update',
   'agent:review',
   'agent:publish',
+  'approval:read',
+  'approval:decide',
+  'evaluation:read',
+  'evaluation:manage',
 ] as const
 export type WorkspaceAction = (typeof WorkspaceActions)[number]
 
 const permissions: Readonly<Record<WorkspaceRole, readonly WorkspaceAction[]>> = Object.freeze({
   owner: WorkspaceActions,
-  builder: ['workspace:read', 'agent:read', 'agent:create', 'agent:update'],
-  reviewer: ['workspace:read', 'agent:read', 'agent:review', 'agent:publish'],
-  viewer: ['workspace:read', 'agent:read'],
+  builder: [
+    'workspace:read', 'agent:read', 'agent:create', 'agent:update',
+    'approval:read', 'evaluation:read', 'evaluation:manage',
+  ],
+  reviewer: [
+    'workspace:read', 'agent:read', 'agent:review', 'agent:publish',
+    'approval:read', 'approval:decide', 'evaluation:read',
+  ],
+  viewer: ['workspace:read', 'agent:read', 'evaluation:read'],
 })
 
 export type AuthorizationContext = Readonly<{
@@ -27,16 +37,25 @@ export type AuthorizationContext = Readonly<{
 
 export type AuthorizationDecision = Readonly<{
   allowed: boolean
-  reason: 'allowed' | 'unauthenticated' | 'workspace_required' | 'membership_required' | 'insufficient_role'
+  reason: 'allowed' | 'unauthenticated' | 'workspace_required' | 'membership_required' | 'invalid_role' | 'insufficient_role'
 }>
+
+export function isWorkspaceRole(value: unknown): value is WorkspaceRole {
+  return typeof value === 'string' && (WorkspaceRoles as readonly string[]).includes(value)
+}
+
+export function isWorkspaceAction(value: unknown): value is WorkspaceAction {
+  return typeof value === 'string' && (WorkspaceActions as readonly string[]).includes(value)
+}
 
 export function authorizeWorkspaceAction(
   context: AuthorizationContext,
   action: WorkspaceAction,
 ): AuthorizationDecision {
-  if (!context.userId) return Object.freeze({ allowed: false, reason: 'unauthenticated' })
-  if (!context.workspaceId) return Object.freeze({ allowed: false, reason: 'workspace_required' })
+  if (!context.userId?.trim()) return Object.freeze({ allowed: false, reason: 'unauthenticated' })
+  if (!context.workspaceId?.trim()) return Object.freeze({ allowed: false, reason: 'workspace_required' })
   if (!context.role) return Object.freeze({ allowed: false, reason: 'membership_required' })
+  if (!isWorkspaceRole(context.role)) return Object.freeze({ allowed: false, reason: 'invalid_role' })
 
   const allowed = permissions[context.role].includes(action)
   return Object.freeze({

--- a/packages/auth/test/auth.test.ts
+++ b/packages/auth/test/auth.test.ts
@@ -1,37 +1,56 @@
 import { describe, expect, it } from 'vitest'
-import { authorizeWorkspaceAction, requireWorkspaceAction } from '../src/index.js'
+import {
+  authorizeWorkspaceAction,
+  isWorkspaceAction,
+  isWorkspaceRole,
+  requireWorkspaceAction,
+} from '../src/index.js'
 
 const base = { userId: 'user-1', workspaceId: 'workspace-1' }
 
 describe('workspace authorization', () => {
-  it('denies unauthenticated requests', () => {
-    expect(
-      authorizeWorkspaceAction({ userId: null, workspaceId: 'workspace-1', role: 'owner' }, 'agent:create'),
-    ).toEqual({ allowed: false, reason: 'unauthenticated' })
+  it('denies unauthenticated and blank identities', () => {
+    expect(authorizeWorkspaceAction({ userId: null, workspaceId: 'workspace-1', role: 'owner' }, 'agent:create'))
+      .toEqual({ allowed: false, reason: 'unauthenticated' })
+    expect(authorizeWorkspaceAction({ userId: '   ', workspaceId: 'workspace-1', role: 'owner' }, 'agent:create'))
+      .toEqual({ allowed: false, reason: 'unauthenticated' })
   })
 
-  it('allows builders to create agents', () => {
-    expect(authorizeWorkspaceAction({ ...base, role: 'builder' }, 'agent:create')).toEqual({
-      allowed: true,
-      reason: 'allowed',
-    })
+  it('denies blank workspace identifiers', () => {
+    expect(authorizeWorkspaceAction({ userId: 'user-1', workspaceId: ' ', role: 'owner' }, 'agent:create'))
+      .toEqual({ allowed: false, reason: 'workspace_required' })
   })
 
-  it('prevents builders from publishing', () => {
-    expect(authorizeWorkspaceAction({ ...base, role: 'builder' }, 'agent:publish')).toEqual({
-      allowed: false,
-      reason: 'insufficient_role',
-    })
+  it('validates roles and actions at runtime boundaries', () => {
+    expect(isWorkspaceRole('reviewer')).toBe(true)
+    expect(isWorkspaceRole('admin')).toBe(false)
+    expect(isWorkspaceAction('approval:decide')).toBe(true)
+    expect(isWorkspaceAction('approval:delete')).toBe(false)
   })
 
-  it('allows reviewers to publish but not modify drafts', () => {
+  it('allows builders to create agents and manage evaluations', () => {
+    expect(authorizeWorkspaceAction({ ...base, role: 'builder' }, 'agent:create').allowed).toBe(true)
+    expect(authorizeWorkspaceAction({ ...base, role: 'builder' }, 'evaluation:manage').allowed).toBe(true)
+  })
+
+  it('prevents builders from publishing or deciding approvals', () => {
+    expect(authorizeWorkspaceAction({ ...base, role: 'builder' }, 'agent:publish').allowed).toBe(false)
+    expect(authorizeWorkspaceAction({ ...base, role: 'builder' }, 'approval:decide').allowed).toBe(false)
+  })
+
+  it('allows reviewers to publish and decide approvals but not modify drafts', () => {
     expect(authorizeWorkspaceAction({ ...base, role: 'reviewer' }, 'agent:publish').allowed).toBe(true)
+    expect(authorizeWorkspaceAction({ ...base, role: 'reviewer' }, 'approval:decide').allowed).toBe(true)
     expect(authorizeWorkspaceAction({ ...base, role: 'reviewer' }, 'agent:update').allowed).toBe(false)
   })
 
+  it('keeps viewers read only', () => {
+    expect(authorizeWorkspaceAction({ ...base, role: 'viewer' }, 'agent:read').allowed).toBe(true)
+    expect(authorizeWorkspaceAction({ ...base, role: 'viewer' }, 'evaluation:read').allowed).toBe(true)
+    expect(authorizeWorkspaceAction({ ...base, role: 'viewer' }, 'agent:create').allowed).toBe(false)
+  })
+
   it('throws a typed error when enforcement fails', () => {
-    expect(() => requireWorkspaceAction({ ...base, role: 'viewer' }, 'agent:create')).toThrow(
-      /insufficient_role/,
-    )
+    expect(() => requireWorkspaceAction({ ...base, role: 'viewer' }, 'agent:create')).toThrow(/insufficient_role/)
   })
 })

--- a/scripts/foundation-audit.mjs
+++ b/scripts/foundation-audit.mjs
@@ -1,0 +1,51 @@
+import { readFile, access } from 'node:fs/promises'
+
+const requiredFiles = [
+  'package.json',
+  'pnpm-workspace.yaml',
+  '.github/workflows/ci.yml',
+  '.env.example',
+  'packages/agent-spec/src/index.ts',
+  'packages/auth/src/index.ts',
+  'supabase/migrations/202607170001_agentforge_foundation.sql',
+]
+
+const failures = []
+for (const path of requiredFiles) {
+  try {
+    await access(path)
+  } catch {
+    failures.push(`Missing required foundation file: ${path}`)
+  }
+}
+
+const root = JSON.parse(await readFile('package.json', 'utf8'))
+if (root.private !== true) failures.push('Root package must remain private')
+if (root.packageManager !== 'pnpm@9.15.4') failures.push('packageManager must be pinned to pnpm@9.15.4')
+if (!String(root.engines?.node ?? '').includes('20')) failures.push('Node 20 must be declared in engines')
+
+const env = await readFile('.env.example', 'utf8')
+const forbiddenBrowserSecrets = [
+  'VITE_SUPABASE_SERVICE_KEY',
+  'VITE_OPENAI_API_KEY',
+  'VITE_STRIPE_SECRET_KEY',
+  'NEXT_PUBLIC_SUPABASE_SERVICE_ROLE_KEY',
+  'NEXT_PUBLIC_OPENAI_API_KEY',
+  'NEXT_PUBLIC_STRIPE_SECRET_KEY',
+]
+for (const name of forbiddenBrowserSecrets) {
+  if (env.includes(name)) failures.push(`Server secret is browser exposed in .env.example: ${name}`)
+}
+
+const workspace = await readFile('pnpm-workspace.yaml', 'utf8')
+for (const pattern of ["'apps/*'", "'packages/*'", "'services/*'"]) {
+  if (!workspace.includes(pattern)) failures.push(`Workspace pattern missing: ${pattern}`)
+}
+
+if (failures.length > 0) {
+  console.error('Foundation audit failed:')
+  for (const failure of failures) console.error(`- ${failure}`)
+  process.exit(1)
+}
+
+console.log(`Foundation audit passed (${requiredFiles.length} files, package manager, Node, workspace, and secret checks).`)

--- a/supabase/migrations/202607170005_foundation_integrity.sql
+++ b/supabase/migrations/202607170005_foundation_integrity.sql
@@ -1,0 +1,86 @@
+begin;
+
+create or replace function public.validate_agent_version_workspace()
+returns trigger
+language plpgsql
+set search_path = public
+as $$
+begin
+  if not exists (
+    select 1
+    from public.agents a
+    where a.id = new.agent_id
+      and a.workspace_id = new.workspace_id
+  ) then
+    raise exception 'Agent version workspace must match its agent workspace';
+  end if;
+  return new;
+end;
+$$;
+
+create trigger validate_agent_version_workspace_before_write
+before insert or update of workspace_id, agent_id
+on public.agent_versions
+for each row execute function public.validate_agent_version_workspace();
+
+create or replace function public.validate_current_agent_version()
+returns trigger
+language plpgsql
+set search_path = public
+as $$
+begin
+  if new.current_version_id is not null and not exists (
+    select 1
+    from public.agent_versions v
+    where v.id = new.current_version_id
+      and v.agent_id = new.id
+      and v.workspace_id = new.workspace_id
+  ) then
+    raise exception 'Current agent version must belong to the same agent and workspace';
+  end if;
+  return new;
+end;
+$$;
+
+create trigger validate_current_agent_version_before_write
+before insert or update of current_version_id, workspace_id
+on public.agents
+for each row execute function public.validate_current_agent_version();
+
+create or replace function public.prevent_agent_version_identity_mutation()
+returns trigger
+language plpgsql
+set search_path = public
+as $$
+begin
+  if old.agent_id <> new.agent_id
+     or old.workspace_id <> new.workspace_id
+     or old.version_number <> new.version_number
+     or old.specification_hash <> new.specification_hash then
+    raise exception 'Agent version identity fields are immutable';
+  end if;
+  return new;
+end;
+$$;
+
+create trigger prevent_agent_version_identity_update
+before update on public.agent_versions
+for each row execute function public.prevent_agent_version_identity_mutation();
+
+create policy versions_update_builder on public.agent_versions
+for update using (
+  public.has_workspace_role(workspace_id, array['owner','builder','reviewer']::public.workspace_role[])
+) with check (
+  public.has_workspace_role(workspace_id, array['owner','builder','reviewer']::public.workspace_role[])
+);
+
+create policy agents_delete_owner on public.agents
+for delete using (
+  public.has_workspace_role(workspace_id, array['owner']::public.workspace_role[])
+);
+
+revoke all on function public.validate_agent_version_workspace() from public;
+revoke all on function public.validate_current_agent_version() from public;
+revoke all on function public.prevent_agent_version_identity_mutation() from public;
+
+commit;


### PR DESCRIPTION
## Summary

Revisits the Days 1–7 foundation and applies twenty focused hardening passes without expanding the MVP into later runtime scope.

## What changed

- Hardened nested Agent Specification validation, normalization, deduplication, numeric integrity, and execution-limit coherence
- Expanded specification tests for nested strictness, duplicates, non-finite values, ordering, and semantic diff stability
- Expanded workspace authorization to cover approvals and evaluations
- Added runtime role/action guards, blank identifier rejection, and broader authorization matrix tests
- Added an executable foundation audit for required files, package-manager/Node consistency, workspace patterns, and browser-exposed secrets
- Wired the foundation audit into `pnpm verify` and CI
- Pinned CI to Node 20.11.1 and added manual workflow dispatch
- Added grouped weekly Dependabot updates
- Added database triggers preventing cross-workspace versions, mismatched current versions, and mutation of version identity fields
- Documented all twenty passes and remaining blockers

## Twenty-pass coverage

Product scope, repository identity, runtime versions, workspace topology, CI triggers, CI gates, dependency maintenance, secret exposure, required files, schema strictness, normalization, duplicate capabilities, numeric integrity, limit coherence, compiler determinism, semantic diffs, authorization vocabulary, authorization runtime boundaries, authorization matrix, and database tenant integrity.

## Validation status

- Branch is 10 commits ahead and 0 behind `main`.
- 10 files changed.
- Source tests, audit script, workflow definitions, and migrations are present.
- The GitHub connector cannot execute dependency installation, TypeScript compilation, unit tests, or Supabase migrations locally.

## Remaining blockers before merge

1. Generate and commit `pnpm-lock.yaml`, then restore frozen installs.
2. Confirm a compatible ESLint flat configuration and run it.
3. Run migrations against a disposable Supabase project.
4. Add cross-workspace RLS integration tests.
5. Confirm the organization/workspace bootstrap path.